### PR TITLE
Add DAP line to site

### DIFF
--- a/src/_includes/layout.njk
+++ b/src/_includes/layout.njk
@@ -20,6 +20,9 @@
   {% include 'footer.njk' %}
   <script src="{{'/assets/js/uswds.min.js' | url}}" type="text/javascript"></script>
 
+  <!-- We participate in the US government's analytics program. See the data at analytics.usa.gov. -->
+  <script async type="text/javascript" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA&subagency=TTS,OROS" id="_fed_an_ua_tag"></script>
+
   <!-- Add Touchpoints intercept -->
   <script src="https://touchpoints.app.cloud.gov/touchpoints/9412c559.js" async></script>
 </body>


### PR DESCRIPTION
This adds the Digital Analytics Program JS line to all pages (public-facing) for this site.