### PR TITLE
Ensure site site can be served from docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,9 @@
 FROM node:17
 
 WORKDIR /app
-COPY package*.json /app
+COPY . /app
 RUN npm install
 
 EXPOSE 8080
 
-# Run 11ty
-# CMD ["npx", "@11ty/eleventy", "--serve", "--port=8080", "--input=src"
 CMD ["npm", "run", "start"]


### PR DESCRIPTION
The Dockerfile wasn't copying over everything the site needed in order to build and serve the app. This PR fixes that. Running the following will build and run a container serving the site:

```
docker build -t fac-site .
docker run -dp 8080:8080 fac-site
```