### PR TITLE
Removed June date for beta testing.

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -37,7 +37,7 @@ We provide regular [FAC updates for federal staff as well as grantees and audito
 
 ## See the FAC
 
-We have [an overview of the FAC process for grantees and auditors](walkthrough/). We will begin beta testing in June, and open for broader testing later this summer.
+We have [an overview of the FAC process for grantees and auditors](walkthrough/).
 
 
 <!-- 


### PR DESCRIPTION
Ahead of sending the email to recruit beta testers, I removed the line from [the homepage](https://federalist-35af9df5-a894-4ae9-aa3d-f6d95427c7bc.sites.pages.cloud.gov/preview/gsa-tts/fac-transition-site/lh/beta-testing-language-removal/) stating beta testing would be starting soon to avoid confusion.

This PR does not include the changes in my previous PR for lh/updating-walkthrough so the two will need to be merged. 