### PR TITLE
Make static site homepage match app

### DIFF
--- a/src/_includes/home.njk
+++ b/src/_includes/home.njk
@@ -2,6 +2,6 @@
 layout: layout.njk
 ---
 
-<div class="grid-container margin-y-4 usa-prose">
+<div class="grid-container margin-y-4">
     {{ content | safe }}
 </div>

--- a/src/index.md
+++ b/src/index.md
@@ -6,36 +6,52 @@ meta:
   description: The Federal Audit Clearinghouse is the home of the single audit process for the federal government awards system.
 ---
 
-# The Federal Audit Clearinghouse
+<div class="usa-hero">
+  <div class="grid-container">
+    <h1 class="usa-hero__heading">
+        The Federal Audit Clearinghouse (FAC) is the place to submit and review federal
+        grant audits.
+    </h1>
 
-The Federal Audit Clearinghouse (FAC) operates on behalf of the Office of Management and Budget (OMB) and is the place to submit and review federal grant audits. 
+    <p class="intro-text">
+        When an organization spends $750,000 or more in federal grant funds in a given year, they are required to
+        submit an audit.
+    </p>
 
+    <p>
+        The FAC is moving to a new home at the General Services Administration (GSA). Only audits from 2022 will be
+        searchable on fac.gov for now.
+        <a href="https://facides.census.gov/Account/Login.aspx" aria-controls="legacy-fac-modal" data-open-modal="" role="button">Please use the U.S. Census Bureau FAC site to search for older records.</a>
+    </p>
 
-<ul class="usa-card-group">
-                <li class="usa-card desktop:grid-col-6">
-                    <div class="usa-card__container">
-                        <div>
-                            <a class="usa-button sign-in-button"
-                               aria-controls="login-modal"
-                               data-open-modal
-                               href="/openid/login/">Sign in</a>
-                        </div>
-                        <p class="usa-card__body">Sign in to submit and review your audits.</p>
-                    </div>
-                </li>
-                <li class="usa-card desktop:grid-col-6">
-                    <div class="usa-card__container">
-                        <div>
-                            <a class="usa-button usa-button--outline"
-                               href="https://facides.census.gov/Account/Login.aspx"
-                               aria-controls="legacy-fac-modal"
-                               data-open-modal>Search older audit reports</a>
-                        </div>
-                        <p class="usa-card__body">
-                            Search audit report records from before 2022.
-                            You don’t need a FAC account to search.
-                        </p>
-                    </div>
-                </li>
-            </ul>
-        </div>
+  <ul class="usa-card-group">
+          <li class="usa-card desktop:grid-col-6">
+              <div class="usa-card__container">
+                  <div>
+                      <a class="usa-button sign-in-button"
+                          aria-controls="login-modal"
+                          data-open-modal
+                          href="/openid/login/">Sign in</a>
+                  </div>
+                  <p class="usa-card__body">Sign in to submit and review your audits.</p>
+              </div>
+          </li>
+          <li class="usa-card desktop:grid-col-6">
+              <div class="usa-card__container">
+                  <div>
+                      <a class="usa-button usa-button--outline"
+                          href="https://facides.census.gov/Account/Login.aspx"
+                          aria-controls="legacy-fac-modal"
+                          data-open-modal>Search older audit reports</a>
+                  </div>
+                  <p class="usa-card__body">
+                      Search audit report records from before 2022.
+                      You don’t need a FAC account to search.
+                  </p>
+              </div>
+          </li>
+      </ul>
+  </div>
+
+  </div>
+</div>

--- a/src/index.md
+++ b/src/index.md
@@ -23,9 +23,7 @@ meta:
             <div class="usa-card__container">
                 <div>
                     <a class="usa-button sign-in-button"
-                        aria-controls="login-modal"
-                        data-open-modal
-                        href="/openid/login/">Sign in</a>
+                        href="https://app.fac.gov/openid/login/">Sign in</a>
                 </div>
                 <p class="usa-card__body">Sign in to submit and review your audits.</p>
             </div>

--- a/src/index.md
+++ b/src/index.md
@@ -18,39 +18,19 @@ meta:
         submit an audit.
     </p>
 
-    <p>
-        The FAC is moving to a new home at the General Services Administration (GSA). Only audits from 2022 will be
-        searchable on fac.gov for now.
-        <a href="https://facides.census.gov/Account/Login.aspx" aria-controls="legacy-fac-modal" data-open-modal="" role="button">Please use the U.S. Census Bureau FAC site to search for older records.</a>
-    </p>
-
-  <ul class="usa-card-group">
-          <li class="usa-card desktop:grid-col-6">
-              <div class="usa-card__container">
-                  <div>
-                      <a class="usa-button sign-in-button"
-                          aria-controls="login-modal"
-                          data-open-modal
-                          href="/openid/login/">Sign in</a>
-                  </div>
-                  <p class="usa-card__body">Sign in to submit and review your audits.</p>
-              </div>
-          </li>
-          <li class="usa-card desktop:grid-col-6">
-              <div class="usa-card__container">
-                  <div>
-                      <a class="usa-button usa-button--outline"
-                          href="https://facides.census.gov/Account/Login.aspx"
-                          aria-controls="legacy-fac-modal"
-                          data-open-modal>Search older audit reports</a>
-                  </div>
-                  <p class="usa-card__body">
-                      Search audit report records from before 2022.
-                      You don’t need a FAC account to search.
-                  </p>
-              </div>
-          </li>
-      </ul>
+    <ul class="usa-card-group flex-align-center flex-justify-center">
+        <li class="usa-card desktop:grid-col-6">
+            <div class="usa-card__container">
+                <div>
+                    <a class="usa-button sign-in-button"
+                        aria-controls="login-modal"
+                        data-open-modal
+                        href="/openid/login/">Sign in</a>
+                </div>
+                <p class="usa-card__body">Sign in to submit and review your audits.</p>
+            </div>
+        </li>
+    </ul>
   </div>
 
   </div>

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -1,5 +1,42 @@
 @use '_header.scss';
 
+.usa-hero {
+  background-image: none;
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.usa-hero__heading {
+    font-size: 2.25rem;
+    margin-top: 0;
+    line-height: 1.2;
+    font-weight: 700;
+}
+
+.usa-hero__heading, .usa-hero p {
+    color: #1b1b1b;
+    font-family: Public Sans Web,
+    -apple-system,
+    BlinkMacSystemFont,
+    Segoe UI,
+    Roboto,
+    Helvetica,
+    Arial,
+    sans-serif,
+    Apple Color Emoji,
+    Segoe UI Emoji,
+    Segoe UI Symbol;
+}
+
+.usa-hero .usa-hero__heading, .usa-hero p, .usa-hero .usa-button-group {
+    margin-bottom: 2.2rem;
+}
+
+.usa-hero .intro-text {
+    border-bottom: 1px solid rgba(0, 0, 0, 0.2);
+    font-size: 1.25rem;
+    padding-bottom: 1.5rem;
+}
 
 .usa-date-picker__button {
   @extend %usa-date-picker__button !optional;
@@ -15,4 +52,9 @@
 
 .usa-card__container {
   margin-top: 2rem;
+}
+
+.usa-card p, .usa-card__body, .usa-card__body:last-child {
+  padding-block-end: 0;
+  margin-block-end: 0;
 }

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -33,9 +33,7 @@
 }
 
 .usa-hero .intro-text {
-    border-bottom: 1px solid rgba(0, 0, 0, 0.2);
     font-size: 1.25rem;
-    padding-bottom: 1.5rem;
 }
 
 .usa-date-picker__button {


### PR DESCRIPTION
This PR just updates the homepage to match the Figma and how the app homepage will (eventually) look

<img width="1066" alt="image" src="https://github.com/GSA-TTS/FAC-transition-site/assets/6290/19a7fd95-7271-4e7c-b84c-29e199d75473">

👀 [Pages preview](https://federalist-35af9df5-a894-4ae9-aa3d-f6d95427c7bc.sites.pages.cloud.gov/preview/gsa-tts/fac-transition-site/mh/sync-templates-1823/)