### PR TITLE
Implement expiring updates

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,4 +1,5 @@
 const yaml = require('js-yaml');
+const { DateTime } = require('luxon');
 
 const pluginRss = require("@11ty/eleventy-plugin-rss");
 const md = require("markdown-it")({
@@ -19,6 +20,21 @@ const hashCode = function(s) {
   return ((hash) >>> 0).toString(16);
 };
 
+const getUnexpiredPosts = function(items) {
+  return items.filter(i => {
+    const expirationDays = i.data.days_until_expiration;
+    const date = i.data.date;
+    const today = DateTime.now();
+
+    if (!expirationDays) return true;
+
+    const expirationDate = DateTime.fromJSDate(new Date(date)).plus({ days: expirationDays }).toJSDate();
+    const isExpired = expirationDate < today;
+
+    return !isExpired;
+  })
+}
+
 module.exports = function(eleventyConfig) {
   eleventyConfig.addDataExtension('yaml', (contents) => yaml.load(contents));
   eleventyConfig.addPassthroughCopy('assets/img');
@@ -32,6 +48,9 @@ module.exports = function(eleventyConfig) {
   eleventyConfig.addFilter("markdown", (markdownString) =>
     md.render(markdownString)
   );
+  eleventyConfig.addFilter("unexpiredPosts", function(pages) {
+    return getUnexpiredPosts(pages);
+  })
 
   return {
     markdownTemplateEngine: "njk",

--- a/src/_collections/updates/2023-08-01-test-expiration-dates.md
+++ b/src/_collections/updates/2023-08-01-test-expiration-dates.md
@@ -1,0 +1,7 @@
+---
+tags: submitters
+date: "2023-08-01"
+days_until_expiration: 30
+---
+
+Hello, if you're seeing this I should be unexpired.

--- a/src/info/updates.md
+++ b/src/info/updates.md
@@ -21,14 +21,15 @@ Updates are sorted with newest posts at the top. The "date" field in the update'
 #}
 
 <ul>
-{% for item in collections.general | sort(true, true, "date") %}
+{% for item in collections.general | unexpiredPosts | sort(true, true, "date") %}
     <li>{{item.content | safe }}</li>
 {% endfor %}
 </ul>
 
 <h3 id="grantees-and-auditors">For grantees and auditors</h3>
 <ul>
-{% for item in collections.submitters | sort(true, true, "data.date") %}
+{#% for item in collections.submitters | sort(true, true, "data.date") %#}
+{% for item in collections.submitters | unexpiredPosts | sort(true, true, "data.date") %}
     <li>{{item.content | safe }}</li>
 {% endfor %}
 </ul>


### PR DESCRIPTION
This PR implements adding expiration dates to updates. There are two changes that need to be made in order to make these work: First, an update that should expire needs both a `date` field in the front matter as well as a new `days_until_expiration` key. Updates that shouldn't expire can just leave out the `days_until_expiration` key. For reference, take a look at [this sample update](https://github.com/GSA-TTS/FAC-transition-site/blob/a37518c95987d818e36d5830c0485534937e5801/src/_collections/updates/2023-08-01-test-expiration-dates.md).

Second, the `unexpiredPosts` filter needs to be added to the template block that is pulling in the updates, as is happening in the `general` and `submitters` updates on the `info/updates` page.

## Action shots

### Current update

<img width="484" alt="image" src="https://github.com/GSA-TTS/FAC-transition-site/assets/6290/02a1234f-53ec-439f-abf8-ff43f2311a40">

<img width="503" alt="image" src="https://github.com/GSA-TTS/FAC-transition-site/assets/6290/f1a3d85c-ab4a-46fa-9c40-e86fdcbe9522">

Notice also that in this example the `unexpiredPosts` filter is chainable into the `sort` filter.

### Expired update

<img width="470" alt="image" src="https://github.com/GSA-TTS/FAC-transition-site/assets/6290/522fd61f-a7f7-44ee-8719-44a82fff7f2f">

<img width="442" alt="image" src="https://github.com/GSA-TTS/FAC-transition-site/assets/6290/df1d5c62-2c26-489b-8a37-0d23afe0ab73">