### PR TITLE
Fix some visual bugs in header

### DIFF
--- a/src/scss/_header.scss
+++ b/src/scss/_header.scss
@@ -51,6 +51,10 @@
       content: url('../img/fac-logo.svg');
     }
   }
+
+  input[type='search'] {
+    max-width: 10em;
+  }
 }
 
 .sign-in,

--- a/src/scss/_header.scss
+++ b/src/scss/_header.scss
@@ -19,9 +19,9 @@
 }
 
 .fac-beta-banner {
-    background-color: color('gold-5v');
-    font-size: .88rem;
-    padding-block: .2rem;
+  background-color: color('gold-5v');
+  font-size: 0.88rem;
+  padding-block: 0.2rem;
 }
 
 .usa-menu-btn {
@@ -30,10 +30,10 @@
 
 .usa-nav__primary button {
   padding: 1rem;
-  padding-left: .5;
-  
+  padding-left: 0.5;
+
   span {
-    padding-right: .5rem;
+    padding-right: 0.5rem;
   }
 }
 .usa-header {
@@ -57,7 +57,7 @@
 .sign-out {
   background-color: color('primary-darker');
   padding: 1em;
-  padding-left: .5rem;
+  padding-left: 0.5rem;
 }
 
 .usa-menu-btn {
@@ -65,7 +65,7 @@
 }
 
 .search {
-  margin-right: .5rem;
+  margin-right: 0.5rem;
 }
 
 .sign-in-logo,
@@ -89,4 +89,3 @@
     display: block;
   }
 }
-


### PR DESCRIPTION
The header is pretty crowded which resulted in some visual bugs:

Before:
<img width="999" alt="image" src="https://github.com/GSA-TTS/FAC-transition-site/assets/6290/5421662a-f113-4acd-8907-0c819f20ea27">

After:
<img width="983" alt="image" src="https://github.com/GSA-TTS/FAC-transition-site/assets/6290/30623bf9-cc5a-4ea8-ab8e-eeab73401266">

[:eyes: Pages preview](https://federalist-35af9df5-a894-4ae9-aa3d-f6d95427c7bc.sites.pages.cloud.gov/preview/gsa-tts/fac-transition-site/mh/fix-janky-chevrons/)