### PR TITLE
Fixing links to workbooks.

### DIFF
--- a/src/resources/workbooks/additional-eins-workbook.njk
+++ b/src/resources/workbooks/additional-eins-workbook.njk
@@ -15,7 +15,7 @@ workbook:
 <div>
   <p>This workbook is only necessary if the single audit report covers multiple EINs.</p>
 
-  <p><a href="{{ config.baseUrl }}assets/workbooks/additional-eins-workbook.xlsx">Download Workbook 8: Additional EINs</a></p> 
+  <p><a href="{{ config.baseUrl }}assets/workbooks/{{workbook.name}}.xlsx">Download {{meta.name}}</a></p>
 
   <h3>If the report covers multiple EINs:</h3>
 

--- a/src/resources/workbooks/additional-ueis-workbook.njk
+++ b/src/resources/workbooks/additional-ueis-workbook.njk
@@ -15,7 +15,7 @@ workbook:
 <div>
   <p>This workbook is only necessary if the single audit report covers multiple UEIs.</p>
 
-  <p><a href="{{ config.baseUrl }}assets/workbooks/additional-ueis-workbook.xlsx">Download Workbook 6: Additional UEIs</a></p> 
+  <p><a href="{{ config.baseUrl }}assets/workbooks/{{workbook.name}}.xlsx">Download {{meta.name}}</a></p>
 
   <h3>If the report covers multiple UEIs:</h3>
 

--- a/src/resources/workbooks/corrective-action-plan.njk
+++ b/src/resources/workbooks/corrective-action-plan.njk
@@ -17,6 +17,8 @@ workbook:
 
   <p>If you do not have a CAP, you must still upload this workbook. Download the workbook, enter your entity UEI, save and upload.</p>
 
+  <p><a href="{{ config.baseUrl }}assets/workbooks/{{workbook.name}}.xlsx">Download {{meta.name}}</a></p>
+
 </div>
   
 <div>

--- a/src/resources/workbooks/federal-awards-audit-findings-text.njk
+++ b/src/resources/workbooks/federal-awards-audit-findings-text.njk
@@ -17,6 +17,7 @@ workbook:
 
   <p>If you do not have any Federal awards findings, you must still upload this workbook. Download the workbook, enter your entity UEI, save and upload.</p>
 
+  <p><a href="{{ config.baseUrl }}assets/workbooks/{{workbook.name}}.xlsx">Download {{meta.name}}</a></p>
 
 </div>
   

--- a/src/resources/workbooks/federal-awards-audit-findings.njk
+++ b/src/resources/workbooks/federal-awards-audit-findings.njk
@@ -17,7 +17,7 @@ workbook:
 
   <p>If you do not have any Federal awards findings, you must still upload this workbook. Download the workbook, enter your entity UEI, save and upload.</p>
 
-  <p><a href="{{ config.baseUrl }}assets/workbooks/federal-awards-audit-findings-workbook.xlsx">Download Workbook 3: Federal awards audit findings</a></p>
+  <p><a href="{{ config.baseUrl }}assets/workbooks/{{workbook.name}}.xlsx">Download {{meta.name}}</a></p>
 
 </div>
   

--- a/src/resources/workbooks/federal-awards.njk
+++ b/src/resources/workbooks/federal-awards.njk
@@ -15,7 +15,7 @@ workbook:
 <div>
   <p>Enter the text of your Federal awards in the provided worksheet using the instructions below.</p>
 
-  <p><a href="{{ config.baseUrl }}assets/workbooks/federal-awards-workbook.xlsx">Download Workbook 1: Federal awards</a></p>
+  <p><a href="{{ config.baseUrl }}assets/workbooks/{{workbook.name}}.xlsx">Download {{meta.name}}</a></p>
 
 </div>
   

--- a/src/resources/workbooks/notes-to-sefa.njk
+++ b/src/resources/workbooks/notes-to-sefa.njk
@@ -50,7 +50,7 @@ workbook:
 <div>
   <p>Enter the text of your Notes to SEFA in the provided worksheet using the instructions below.</p>
 
-    <p><a href="{{ config.baseUrl }}assets/workbooks/notes-to-sefa-workbook.xlsx">Download Workbook 2: Notes to SEFA</a></p> 
+  <p><a href="{{ config.baseUrl }}assets/workbooks/{{workbook.name}}.xlsx">Download {{meta.name}}</a></p>
 
 </div>
   

--- a/src/resources/workbooks/secondary-auditors-workbook.njk
+++ b/src/resources/workbooks/secondary-auditors-workbook.njk
@@ -51,7 +51,7 @@ workbook:
 <div>
   <p>This workbook is only necessary if multiple auditors did the audit work.</p>
 
-  <p><a href="{{ config.baseUrl }}assets/workbooks/secondary-auditors-workbook.xlsx">Download Workbook 7: Secondary auditors</a></p>
+  <p><a href="{{ config.baseUrl }}assets/workbooks/{{workbook.name}}.xlsx">Download {{meta.name}}</a></p>
 
   <h3>If you have secondary auditors:</h3>
 


### PR DESCRIPTION
We lost two sometime in the past to a merge.

This uses the top-of-page metadata for all of the workbook links. That way, all the HTML is the same, and is driven by the metadata in the page.