### PR TITLE
Fixes a small, but important, URL documentation error.

### DIFF
--- a/src/developers/getting-started.md
+++ b/src/developers/getting-started.md
@@ -14,7 +14,7 @@ The examples in this repository assume that you have two environment variables s
 
 ```
 export API_GOV_KEY="..."
-export API_GOV_URL="https://api-staging.fac.gov/"
+export API_GOV_URL="https://api-staging.fac.gov"
 ```
 
 Those two environment variables must be present in your shell for the code provided to work "as is." 
@@ -36,7 +36,6 @@ You can set `API_GOV_URL` to one of four URLs:
 2. `api-staging.fac.gov`: This endpoint will contain a mix of submitted data as well as test data. This environment is updated daily at 5 a.m. ET.
 3. `api-dev.fac.gov`: This endpoint may contain a mix of submitted and test data. Every time we accept a pull request into `main`, this environment updates. `dev` is considered unstable.
 4. `api-preview.fac.gov`: This is a testing environment for our FAC developers. You shouldn't use `preview` unless asked to by the FAC team.
-
 
 ## Testing the API
 


### PR DESCRIPTION
We had a trailing slash somewhere we shouldn't have, and it introduce an error for our users when they were working through the documentation.

This single-character fix should improve the docs and eliminate that error pathway.