### PR TITLE
Fixing a missing close anchor tag.

### DIFF
--- a/src/developers/index.md
+++ b/src/developers/index.md
@@ -25,7 +25,7 @@ To interact with the FAC API, you will need an API key from <a href="https://dat
 Once you have your API key, you can begin exploring the API:
 * [Get started from the command-line]({{ config.baseUrl }}developers/getting-started/).
 * Browse our [endpoint documentation]({{ config.baseUrl }}developers/v1_0_0/).
-* Browse PostgREST's <a href="https://postgrest.org/en/stable/references/api/tables_views.html" target="_blank">query operations documentation.
+* Browse PostgREST's <a href="https://postgrest.org/en/stable/references/api/tables_views.html" target="_blank">query operations documentation</a>.
 
 ## API limits and future updates
 


### PR DESCRIPTION
A tag went missing on the developer page. A link ran away. I replaced a missing tag.