### PR TITLE
Updated instructions for workbooks 3-5

### DIFF
--- a/src/resources/workbooks/corrective-action-plan.njk
+++ b/src/resources/workbooks/corrective-action-plan.njk
@@ -13,9 +13,7 @@ workbook:
 <h2>Workbook 5: Corrective action plan</h2>
 
 <div>
-  <p>Enter your Corrective Action Plan (CAP) using the provided worksheet.</p>
-
-  <p>If you do not have a CAP, you must still upload this workbook. Download the workbook, enter your entity UEI, save and upload.</p>
+  <p>This workbook is only necessary if you have Federal awards findings. If you do not have any Federal awards findings, you do not have to upload this workbook.</p>
 
   <p><a href="{{ config.baseUrl }}assets/workbooks/{{workbook.name}}.xlsx">Download {{meta.name}}</a></p>
 

--- a/src/resources/workbooks/federal-awards-audit-findings-text.njk
+++ b/src/resources/workbooks/federal-awards-audit-findings-text.njk
@@ -13,9 +13,7 @@ workbook:
 <h2>Workbook 4: Federal awards audit findings text</h2>
 
 <div>
-  <p>Enter your Federal awards findings text using the provided worksheet.</p>
-
-  <p>If you do not have any Federal awards findings, you must still upload this workbook. Download the workbook, enter your entity UEI, save and upload.</p>
+  <p>This workbook is only necessary if you have Federal awards findings. If you do not have any Federal awards findings, you do not have to upload this workbook.</p>
 
   <p><a href="{{ config.baseUrl }}assets/workbooks/{{workbook.name}}.xlsx">Download {{meta.name}}</a></p>
 

--- a/src/resources/workbooks/federal-awards-audit-findings.njk
+++ b/src/resources/workbooks/federal-awards-audit-findings.njk
@@ -13,9 +13,7 @@ workbook:
 <h2>Workbook 3: Federal awards audit findings</h2>
 
 <div>
-  <p>Enter your Federal awards findings using the provided worksheet.</p>
-
-  <p>If you do not have any Federal awards findings, you must still upload this workbook. Download the workbook, enter your entity UEI, save and upload.</p>
+  <p>This workbook is only necessary if you have Federal awards findings. If you do not have any Federal awards findings, you do not have to upload this workbook.</p>
 
   <p><a href="{{ config.baseUrl }}assets/workbooks/{{workbook.name}}.xlsx">Download {{meta.name}}</a></p>
 


### PR DESCRIPTION
Updated the instructions for workbooks 3-5 to reflect that these are not necessary unless there are audit findings. The text is the same for all three. The pages updated are:

- [Workbook 3](https://federalist-35af9df5-a894-4ae9-aa3d-f6d95427c7bc.sites.pages.cloud.gov/preview/gsa-tts/fac-transition-site/lh/workbook-instruction-updates/resources/workbooks/federal-awards-audit-findings/)
- [Workbook 4](https://federalist-35af9df5-a894-4ae9-aa3d-f6d95427c7bc.sites.pages.cloud.gov/preview/gsa-tts/fac-transition-site/lh/workbook-instruction-updates/resources/workbooks/federal-awards-audit-findings-text/)
- [Workbook 5](https://federalist-35af9df5-a894-4ae9-aa3d-f6d95427c7bc.sites.pages.cloud.gov/preview/gsa-tts/fac-transition-site/lh/workbook-instruction-updates/resources/workbooks/corrective-action-plan/)

<img width="1335" alt="Screenshot 2023-10-05 at 12 29 54 PM" src="https://github.com/GSA-TTS/FAC-transition-site/assets/123114420/cf2fc7f6-61ae-4cda-abba-5d5fb6f41687">
