### PR TITLE
Lh/unlock updates

### DIFF
--- a/src/_collections/updates/2023-09-08-05-late-audits.md
+++ b/src/_collections/updates/2023-09-08-05-late-audits.md
@@ -1,5 +1,5 @@
 ---
-tags: submitters
+tags: 
 date: "2023-09-08"
 ---
 We will begin accepting late audit submissions for prior years on November 1, 2023. Auditees won't be able to amend audits until later in the year.

--- a/src/_collections/walkthrough/14-lock.md
+++ b/src/_collections/walkthrough/14-lock.md
@@ -1,10 +1,12 @@
 ---
 tags: walkthrough
 title: Lock for certification
-image: walkthrough_13.png
+image: walkthrough_14.png
 ---
 
-After you have validated your data, you will lock your single audit submission for certification. Once you have locked it, you will not be able to edit or make changes to your single audit submission.
+After validation, you will lock your single audit submission for certification. 
+
+If you need to make edits after this step, you may unlock your submission from the audit status page. Before certification, you will have to re-validate and re-lock your data.
 
 Make sure you save copies of your documents to your local drive before moving on to certification as **the FAC does not maintain versions for you**.
 

--- a/src/_collections/walkthrough/15-certification.md
+++ b/src/_collections/walkthrough/15-certification.md
@@ -1,7 +1,7 @@
 ---
 tags: walkthrough
 title: Audit certification process
-image: walkthrough_14.png
+image: walkthrough_15.png
 ---
 
 After you've completed the pre-certification validation, you can begin the certification process.

--- a/src/_collections/walkthrough/16-confirmation.md
+++ b/src/_collections/walkthrough/16-confirmation.md
@@ -1,7 +1,7 @@
 ---
 tags: walkthrough
 title: Confirming submission
-image: walkthrough_15.png
+image: walkthrough_16.png
 ---
 
 The submission process is complete.


### PR DESCRIPTION
The following changes are included:

- Updated copy on How To to reflect [new ability to unlock submissions before certification](https://federalist-35af9df5-a894-4ae9-aa3d-f6d95427c7bc.sites.pages.cloud.gov/preview/gsa-tts/fac-transition-site/lh/unlock-updates/resources/instructions/#lock-for-certification)
- Fixed the order of screenshots in How To ([last two](https://federalist-35af9df5-a894-4ae9-aa3d-f6d95427c7bc.sites.pages.cloud.gov/preview/gsa-tts/fac-transition-site/lh/unlock-updates/resources/instructions/#audit-certification-process) were repeats)
- Removed mention on [Updates page](https://federalist-35af9df5-a894-4ae9-aa3d-f6d95427c7bc.sites.pages.cloud.gov/preview/gsa-tts/fac-transition-site/lh/unlock-updates/info/updates/) about not accepting prior year audits until November
<img width="1296" alt="Screenshot 2023-10-24 at 10 19 09 AM" src="https://github.com/GSA-TTS/FAC-transition-site/assets/123114420/96e29b55-ad8d-4617-9734-9b1b80a6d7be">
<img width="1197" alt="Screenshot 2023-10-24 at 9 00 16 AM" src="https://github.com/GSA-TTS/FAC-transition-site/assets/123114420/fb142548-56b5-4966-a7bc-0f7c9e459beb">
