### PR TITLE
Lh/oct23 updates

### DIFF
--- a/src/info/updates/archive.md
+++ b/src/info/updates/archive.md
@@ -10,6 +10,25 @@ meta:
 
 The FAC is committed to working transparently and openly. In addition to our regular updates, you can find historical updates below.
 
+## Week of October 16, 2023
+
+We released the GSA FAC as a minimal viable product. That means we are continuing to work and improve the FAC. [We work in an agile manner](https://asana.com/resources/agile-methodology).
+
+### Items of note:
+- <p>All UEIs are validating.</p>
+- <p>We made significant improvements to workbook validations and their associated instructions.</p>
+
+If you previously encountered challenges submitting your workbooks, we recommend you try again.
+### What's next?
+
+We are currently working on [search](https://github.com/GSA-TTS/FAC/issues/2236). We hope to demonstrate a prototype to Federal partners this week for early feedback. We anticipate having the ability to search for and download audits by the end of October.
+
+Our pending feature priorities are:
+- Adding the ability to unlock audit submissions to edit and then re-lock for certification instead of starting a new submission.
+- Adding the ability to add, remove, or change auditors and certifying officials who are attached to the audit.
+- Adding the ability to resubmit a previously submitted and completed audit.
+- Adding email notifications to alert auditees and auditors that a step is ready for them to complete.
+
 ## Week of October 9, 2023
 
 We released the GSA FAC as a minimal viable product. That means we are continuing to work and improve the FAC. [We work in an agile manner](https://asana.com/resources/agile-methodology).

--- a/src/info/updates/index.md
+++ b/src/info/updates/index.md
@@ -19,24 +19,73 @@ The Federal Audit Clearinghouse team works in the open. Our day-to-day task boar
 * Updates for [grantees and auditors](#grantees-and-auditors)
 * Updates for [agencies](#agencies)
 
-## Week of October 16, 2023
+## Week of October 23, 2023
 
-We released the GSA FAC as a minimal viable product. That means we are continuing to work and improve the FAC. [We work in an agile manner](https://asana.com/resources/agile-methodology).
+The FAC participated in the Single Audit Roundtable, providing an update on our work to date and planned next steps, and used the opportunity to discuss pressing needs for auditors, resolution officials, and IGs.
+
+We released the GSA FAC as a minimal viable product. That means we are continuing to work and improve the FAC.
+
+### What we delivered
+
+We work in [an agile manner](https://asana.com/resources/agile-methodology). That means we have a long-term strategy, medium-term features we work to deliver, and make continuous improvement and bug fixes to the existing product. We update our system through pull requests, or PRs.
+
+- Improvements take existing code or text and increase its quality
+- Features add new capabilities or documentation to the FAC
+- Validations increase the integrity of the data collected or disseminated by the FAC.
+
+During the week of October 16th, the FAC team merged the following PRs that improved, added features to, or improved the validation of data in the system.
+
+<table class="usa-table">
+  <caption>
+    FAC code releases for the week of Oct. 16, 2023.
+  </caption>
+  <thead>
+    <tr>
+      <th scope="col">PR</th>
+      <th scope="col">Type</th>
+      <th scope="col">Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2569>2569</a></th>
+      <td>
+        Feature
+      </td>
+      <td>Add system command for generating test data in production environments</td>
+    </tr>
+    <tr>
+      <th scope="row">Bill of Rights</th>
+      <td>
+        The first ten amendments of the U.S. Constitution guaranteeing rights
+        and freedoms.
+      </td>
+      <td>1791</td>
+    </tr>
+    <tr>
+      <th scope="row">Declaration of Sentiments</th>
+      <td>
+        A document written during the Seneca Falls Convention outlining the
+        rights that American women should be entitled to as citizens.
+      </td>
+      <td>1848</td>
+    </tr>
+    <tr>
+      <th scope="row">Emancipation Proclamation</th>
+      <td>
+        An executive order granting freedom to slaves in designated southern
+        states.
+      </td>
+      <td>1863</td>
+    </tr>
+  </tbody>
+</table>
 
 ### Items of note:
-- <p>All UEIs are validating.</p>
-- <p>We made significant improvements to workbook validations and their associated instructions.</p>
 
-If you previously encountered challenges submitting your workbooks, we recommend you try again.
 ### What's next?
 
-We are currently working on [search](https://github.com/GSA-TTS/FAC/issues/2236). We hope to demonstrate a prototype to Federal partners this week for early feedback. We anticipate having the ability to search for and download audits by the end of October.
 
-Our pending feature priorities are:
-- Adding the ability to unlock audit submissions to edit and then re-lock for certification instead of starting a new submission.
-- Adding the ability to add, remove, or change auditors and certifying officials who are attached to the audit.
-- Adding the ability to resubmit a previously submitted and completed audit.
-- Adding email notifications to alert auditees and auditors that a step is ready for them to complete.
 
 <h2 id="general" >General updates</h3>
 

--- a/src/info/updates/index.md
+++ b/src/info/updates/index.md
@@ -55,37 +55,110 @@ During the week of October 16th, the FAC team merged the following PRs that impr
       <td>Add system command for generating test data in production environments</td>
     </tr>
     <tr>
-      <th scope="row">Bill of Rights</th>
+      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2572>2572</a></th>
       <td>
-        The first ten amendments of the U.S. Constitution guaranteeing rights
-        and freedoms.
+        Feature
       </td>
-      <td>1791</td>
+      <td>Allow users to unlock submissions once locked</td>
     </tr>
     <tr>
-      <th scope="row">Declaration of Sentiments</th>
+      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2610>2610</a></th>
       <td>
-        A document written during the Seneca Falls Convention outlining the
-        rights that American women should be entitled to as citizens.
+        Feature
       </td>
-      <td>1848</td>
+      <td>Create backup of media files</td>
     </tr>
     <tr>
-      <th scope="row">Emancipation Proclamation</th>
+      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2617>2617</a></th>
       <td>
-        An executive order granting freedom to slaves in designated southern
-        states.
+        Feature
       </td>
-      <td>1863</td>
+      <td>Test data for historical data migration</td>
+    </tr>
+    <tr>
+      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2627>2627</a></th>
+      <td>
+        Feature
+      </td>
+      <td>Prepare workbook generator for use in historical migration</td>
+    </tr>
+    <tr>
+      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2563>2563</a></th>
+      <td>
+        Improvement
+      </td>
+      <td>Test data generator improvements to align with data intake checks</td>
+    </tr>
+    <tr>
+      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2568>2568</a></th>
+      <td>
+        Improvement
+      </td>
+      <td>Code simplification in end-to-end test environment</td>
+    </tr>
+    <tr>
+      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2571>2571</a></th>
+      <td>
+        Improvement
+      </td>
+      <td>Improve data generation command for reuse across environments</td>
+    </tr>
+    <tr>
+      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2595>2595</a></th>
+      <td>
+        Improvement
+      </td>
+      <td>Copy improvements and styling for submission unlock</td>
+    </tr>
+    <tr>
+      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2596>2596</a></th>
+      <td>
+        Improvement
+      </td>
+      <td>Remove unused application code</td>
+    </tr>
+    <tr>
+      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2613>2613</a></th>
+      <td>
+        Improvement
+      </td>
+      <td>Fix PDF download infrastructure</td>
+    </tr>
+    <tr>
+      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2624>2624</a></th>
+      <td>
+        Improvement
+      </td>
+      <td>Update software versions for deployment automations</td>
+    </tr>
+    <tr>
+      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2586>2586</a></th>
+      <td>
+        Validation
+      </td>
+      <td>Assert all data ranges expected are present in workbooks</td>
     </tr>
   </tbody>
 </table>
 
-### Items of note:
+### Challenges
+
+We encountered a bug on Friday, October 27th. This is not a bug in our software, but in one of our support systems. We are working with our systems providers to understand this bug and resolve it. Until it is resolved, we have to slow releases into our production environment. **This bug does not impact data quality or the current operation of the FAC.**
 
 ### What's next?
 
+We are currently working on [search](https://github.com/GSA-TTS/FAC/issues/2236). We have a version ready for release, but are unable to promote it to production due to underlying system issues. Search includes the ability to download PDFs, both via the website and API.
 
+After releasing search, our priorities are:
+- Adding the ability to add, remove, or change auditors and certifying officials who are attached to the audit.
+- Adding the ability to search for and download Tribal audits.
+- Adding the ability to resubmit a previously submitted and completed audit.
+- Adding email notifications to alert auditees and auditors that a step is ready for them to complete.
+- Adding the ability to bulk download search results.
+
+### Opportunities
+
+Do you have an idea that could transform and improve grants management and oversight? 10x, a federal idea accelerator, is [accepting proposals for new investment opportunities](https://10x.gsa.gov/posts/2023-submission-period/). All Federal employees are invited to submit ideas by November 30th.
 
 <h2 id="general" >General updates</h3>
 

--- a/src/info/updates/index.md
+++ b/src/info/updates/index.md
@@ -33,8 +33,6 @@ We work in [an agile manner](https://asana.com/resources/agile-methodology). Tha
 - Improvements take existing code or text and increase its quality
 - Validations increase the integrity of the data collected or disseminated by the FAC.
 
-During the week of October 16th, the FAC team merged the following PRs.
-
 <table class="usa-table">
   <caption>
     FAC feature additions, system improvements, and data validations for the week of October 16, 2023.

--- a/src/info/updates/index.md
+++ b/src/info/updates/index.md
@@ -29,15 +29,15 @@ We released the GSA FAC as a minimal viable product. That means we are continuin
 
 We work in [an agile manner](https://asana.com/resources/agile-methodology). That means we have a long-term strategy, medium-term features we work to deliver, and make continuous improvement and bug fixes to the existing product. We update our system through pull requests, or PRs.
 
-- Improvements take existing code or text and increase its quality
 - Features add new capabilities or documentation to the FAC
+- Improvements take existing code or text and increase its quality
 - Validations increase the integrity of the data collected or disseminated by the FAC.
 
-During the week of October 16th, the FAC team merged the following PRs that improved, added features to, or improved the validation of data in the system.
+During the week of October 16th, the FAC team merged the following PRs.
 
 <table class="usa-table">
   <caption>
-    FAC code releases for the week of Oct. 16, 2023.
+    FAC feature additions, system improvements, and data validations for the week of October 16, 2023.
   </caption>
   <thead>
     <tr>


### PR DESCRIPTION
Added w/o Oct. 23rd changes to [Updates from the FAC page](https://federalist-35af9df5-a894-4ae9-aa3d-f6d95427c7bc.sites.pages.cloud.gov/preview/gsa-tts/fac-transition-site/lh/oct23-updates/info/updates/) and moved w/o Oct. 16 to [the Updates Archive](https://federalist-35af9df5-a894-4ae9-aa3d-f6d95427c7bc.sites.pages.cloud.gov/preview/gsa-tts/fac-transition-site/lh/oct23-updates/info/updates/archive/).
![Screenshot 2023-11-01 at 10-22-06 Archived updates from the FAC](https://github.com/GSA-TTS/FAC-transition-site/assets/123114420/a28df4a5-6157-4bd8-a586-f07e2e6e864a)
![Screenshot 2023-11-01 at 10-21-50 Updates from the FAC](https://github.com/GSA-TTS/FAC-transition-site/assets/123114420/1b15726a-c9ed-46e5-9818-dd1e8bf79795)
