### PR TITLE
Lh/adding search

### DIFF
--- a/src/audits/index.md
+++ b/src/audits/index.md
@@ -12,7 +12,7 @@ Our goal is to make the single audit submission process as easy as possible.
 
 ## How-to
 
-Our [how-to guide]({{ config.baseUrl }} resources/instructions) will take you through submitting a single audit, from creating a Login.gov account to certification and submission.
+Our [how-to guide]({{ config.baseUrl }}resources/instructions) will take you through submitting a single audit, from creating a Login.gov account to certification and submission.
 
 ## Single audit workbooks
 

--- a/src/audits/index.md
+++ b/src/audits/index.md
@@ -12,7 +12,7 @@ Our goal is to make the single audit submission process as easy as possible.
 
 ## How-to
 
-Our [how-to guide]({{ config.baseUrl }}/resources/instructions) will take you through submitting a single audit, from creating a Login.gov account to certification and submission.
+Our [how-to guide]({{ config.baseUrl }} resources/instructions) will take you through submitting a single audit, from creating a Login.gov account to certification and submission.
 
 ## Single audit workbooks
 


### PR DESCRIPTION
Fixed a broken URL from [the Audits resources page](https://federalist-35af9df5-a894-4ae9-aa3d-f6d95427c7bc.sites.pages.cloud.gov/preview/gsa-tts/fac-transition-site/lh/adding-search/audits/) to [the How-To page](https://federalist-35af9df5-a894-4ae9-aa3d-f6d95427c7bc.sites.pages.cloud.gov/preview/gsa-tts/fac-transition-site/lh/adding-search/resources/instructions/).