### PR TITLE
Lh/oct30 updates

### DIFF
--- a/src/_collections/updates/2023-09-08-02-search.md
+++ b/src/_collections/updates/2023-09-08-02-search.md
@@ -1,5 +1,5 @@
 ---
-tags: general
+tags:
 date: "2023-09-08"
 ---
 Single audit data for  fiscal year 2023 will be available via search in mid-October.

--- a/src/_collections/updates/2023-09-08-03-api.md
+++ b/src/_collections/updates/2023-09-08-03-api.md
@@ -1,5 +1,5 @@
 ---
-tags: general
+tags: 
 date: "2023-09-08"
 ---
 2023 audit data will be available immediately via [the FAC API]({{ config.baseUrl }}developers).

--- a/src/info/updates/archive.md
+++ b/src/info/updates/archive.md
@@ -10,6 +10,145 @@ meta:
 
 The FAC is committed to working transparently and openly. In addition to our regular updates, you can find historical updates below.
 
+## Week of October 23, 2023
+
+The FAC participated in the Single Audit Roundtable, providing an update on our work to date and planned next steps, and used the opportunity to discuss pressing needs for auditors, resolution officials, and IGs.
+
+We released the GSA FAC as a minimal viable product. That means we are continuing to work and improve the FAC.
+
+### What we delivered
+
+We work in [an agile manner](https://asana.com/resources/agile-methodology). That means we have a long-term strategy, medium-term features we work to deliver, and make continuous improvement and bug fixes to the existing product. We update our system through pull requests, or PRs.
+
+- Features add new capabilities or documentation to the FAC
+- Improvements take existing code or text and increase its quality
+- Validations increase the integrity of the data collected or disseminated by the FAC.
+
+<table class="usa-table">
+  <caption>
+    FAC feature additions, system improvements, and data validations for the week of October 16, 2023.
+  </caption>
+  <thead>
+    <tr>
+      <th scope="col">PR</th>
+      <th scope="col">Type</th>
+      <th scope="col">Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2569>2569</a></th>
+      <td>
+        Feature
+      </td>
+      <td>Add system command for generating test data in production environments</td>
+    </tr>
+    <tr>
+      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2572>2572</a></th>
+      <td>
+        Feature
+      </td>
+      <td>Allow users to unlock submissions once locked</td>
+    </tr>
+    <tr>
+      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2610>2610</a></th>
+      <td>
+        Feature
+      </td>
+      <td>Create backup of media files</td>
+    </tr>
+    <tr>
+      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2617>2617</a></th>
+      <td>
+        Feature
+      </td>
+      <td>Test data for historical data migration</td>
+    </tr>
+    <tr>
+      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2627>2627</a></th>
+      <td>
+        Feature
+      </td>
+      <td>Prepare workbook generator for use in historical migration</td>
+    </tr>
+    <tr>
+      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2563>2563</a></th>
+      <td>
+        Improvement
+      </td>
+      <td>Test data generator improvements to align with data intake checks</td>
+    </tr>
+    <tr>
+      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2568>2568</a></th>
+      <td>
+        Improvement
+      </td>
+      <td>Code simplification in end-to-end test environment</td>
+    </tr>
+    <tr>
+      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2571>2571</a></th>
+      <td>
+        Improvement
+      </td>
+      <td>Improve data generation command for reuse across environments</td>
+    </tr>
+    <tr>
+      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2595>2595</a></th>
+      <td>
+        Improvement
+      </td>
+      <td>Copy improvements and styling for submission unlock</td>
+    </tr>
+    <tr>
+      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2596>2596</a></th>
+      <td>
+        Improvement
+      </td>
+      <td>Remove unused application code</td>
+    </tr>
+    <tr>
+      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2613>2613</a></th>
+      <td>
+        Improvement
+      </td>
+      <td>Fix PDF download infrastructure</td>
+    </tr>
+    <tr>
+      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2624>2624</a></th>
+      <td>
+        Improvement
+      </td>
+      <td>Update software versions for deployment automations</td>
+    </tr>
+    <tr>
+      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2586>2586</a></th>
+      <td>
+        Validation
+      </td>
+      <td>Assert all data ranges expected are present in workbooks</td>
+    </tr>
+  </tbody>
+</table>
+
+### Challenges
+
+We encountered a bug on Friday, October 27th. This is not a bug in our software, but in one of our support systems. We are working with our systems providers to understand this bug and resolve it. Until it is resolved, we have to slow releases into our production environment. **This bug does not impact data quality or the current operation of the FAC.**
+
+### What's next?
+
+We are currently working on [search](https://github.com/GSA-TTS/FAC/issues/2236). We have a version ready for release, but are unable to promote it to production due to underlying system issues. Search includes the ability to download PDFs, both via the website and API.
+
+After releasing search, our priorities are:
+- Adding the ability to add, remove, or change auditors and certifying officials who are attached to the audit.
+- Adding the ability to search for and download Tribal audits.
+- Adding the ability to resubmit a previously submitted and completed audit.
+- Adding email notifications to alert auditees and auditors that a step is ready for them to complete.
+- Adding the ability to bulk download search results.
+
+### Opportunities
+
+Do you have an idea that could transform and improve grants management and oversight? 10x, a federal idea accelerator, is [accepting proposals for new investment opportunities](https://10x.gsa.gov/posts/2023-submission-period/). All Federal employees are invited to submit ideas by November 30th.
+
 ## Week of October 16, 2023
 
 We released the GSA FAC as a minimal viable product. That means we are continuing to work and improve the FAC. [We work in an agile manner](https://asana.com/resources/agile-methodology).

--- a/src/info/updates/index.md
+++ b/src/info/updates/index.md
@@ -19,23 +19,23 @@ The Federal Audit Clearinghouse team works in the open. Our day-to-day task boar
 * Updates for [grantees and auditors](#grantees-and-auditors)
 * Updates for [agencies](#agencies)
 
-## Week of October 23, 2023
+## Week of October 30, 2023
 
-The FAC participated in the Single Audit Roundtable, providing an update on our work to date and planned next steps, and used the opportunity to discuss pressing needs for auditors, resolution officials, and IGs.
-
-We released the GSA FAC as a minimal viable product. That means we are continuing to work and improve the FAC.
+We launched search and are ready for users to begin searching single audit reports. This initial iteration of search leverages six different filters for sorting data.
 
 ### What we delivered
 
 We work in [an agile manner](https://asana.com/resources/agile-methodology). That means we have a long-term strategy, medium-term features we work to deliver, and make continuous improvement and bug fixes to the existing product. We update our system through pull requests, or PRs.
 
-- Features add new capabilities or documentation to the FAC
-- Improvements take existing code or text and increase its quality
+- Features add new capabilities or documentation to the FAC.
+- Improvements take existing code or text and increase its quality.
 - Validations increase the integrity of the data collected or disseminated by the FAC.
+- Decision records chart our product planning and decision making process.
+- Debt payment removes, cleans up, or otherwise improves existing code.
 
 <table class="usa-table">
   <caption>
-    FAC feature additions, system improvements, and data validations for the week of October 16, 2023.
+    FAC feature additions, system improvements, and data validations for the week of October 30, 2023.
   </caption>
   <thead>
     <tr>
@@ -46,113 +46,130 @@ We work in [an agile manner](https://asana.com/resources/agile-methodology). Tha
   </thead>
   <tbody>
     <tr>
-      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2569>2569</a></th>
+      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2725>2725</a></th>
       <td>
         Feature
       </td>
-      <td>Add system command for generating test data in production environments</td>
+      <td>Foundation for historic data migration</td>
     </tr>
     <tr>
-      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2572>2572</a></th>
+      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2681>2681</a></th>
       <td>
         Feature
       </td>
-      <td>Allow users to unlock submissions once locked</td>
+      <td>Reporting infrastructure rollout</td>
     </tr>
     <tr>
-      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2610>2610</a></th>
-      <td>
-        Feature
-      </td>
-      <td>Create backup of media files</td>
-    </tr>
-    <tr>
-      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2617>2617</a></th>
-      <td>
-        Feature
-      </td>
-      <td>Test data for historical data migration</td>
-    </tr>
-    <tr>
-      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2627>2627</a></th>
-      <td>
-        Feature
-      </td>
-      <td>Prepare workbook generator for use in historical migration</td>
-    </tr>
-    <tr>
-      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2563>2563</a></th>
+      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2764>2764</a></th>
       <td>
         Improvement
       </td>
-      <td>Test data generator improvements to align with data intake checks</td>
+      <td>Fixes to workbook generation for historic data migration</td>
     </tr>
     <tr>
-      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2568>2568</a></th>
+      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2724>2724</a></th>
       <td>
         Improvement
       </td>
-      <td>Code simplification in end-to-end test environment</td>
+      <td>Improvements to the initial release of search</td>
     </tr>
     <tr>
-      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2571>2571</a></th>
+      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2734>2734</a></th>
       <td>
         Improvement
       </td>
-      <td>Improve data generation command for reuse across environments</td>
+      <td>Fixes to search on ALNs</td>
     </tr>
     <tr>
-      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2595>2595</a></th>
+      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2733>2733</a></th>
       <td>
         Improvement
       </td>
-      <td>Copy improvements and styling for submission unlock</td>
+      <td>Consistent linking of search from fac.gov and application</td>
     </tr>
     <tr>
-      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2596>2596</a></th>
+      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2728>2728</a></th>
       <td>
         Improvement
       </td>
-      <td>Remove unused application code</td>
+      <td>Cleanup of documents regarding product decisions</td>
     </tr>
     <tr>
-      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2613>2613</a></th>
+      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2683>2683</a></th>
       <td>
         Improvement
       </td>
-      <td>Fix PDF download infrastructure</td>
+      <td>Pagination in search results</td>
     </tr>
     <tr>
-      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2624>2624</a></th>
+      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2663>2663</a></th>
       <td>
         Improvement
       </td>
-      <td>Update software versions for deployment automations</td>
+      <td>Updating privacy ACLs after AWS S3 changes</td>
     </tr>
     <tr>
-      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2586>2586</a></th>
+      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2642>2642</a></th>
+      <td>
+        Improvement
+      </td>
+      <td>Inexact matches on search fields</td>
+    </tr>
+    <tr>
+      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2651>2651</a></th>
       <td>
         Validation
       </td>
-      <td>Assert all data ranges expected are present in workbooks</td>
+      <td>Placeholder for future workbook version checks</td>
+    </tr>
+    <tr>
+      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2640>2640</a></th>
+      <td>
+        Validation
+      </td>
+      <td>Improved validation around spaces in T3</td>
+    </tr>
+    <tr>
+      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2766>2766</a></th>
+      <td>
+        Decision
+      </td>
+      <td>User permission design for tribal audit access</td>
+    </tr>
+    <tr>
+      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2749>2749</a></th>
+      <td>
+        Decision
+      </td>
+      <td>New process for product decision making</td>
+    </tr>
+    <tr>
+      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2750>2750</a></th>
+      <td>
+        Decision
+      </td>
+      <td>Revision to decision making process</td>
+    </tr>
+    <tr>
+      <th scope="row"><a href=https://github.com/GSA-TTS/FAC/pull/2686>2686</a></th>
+      <td>
+        Debt
+      </td>
+      <td>Removed “cms,” unused portions of code</td>
     </tr>
   </tbody>
 </table>
 
-### Challenges
-
-We encountered a bug on Friday, October 27th. This is not a bug in our software, but in one of our support systems. We are working with our systems providers to understand this bug and resolve it. Until it is resolved, we have to slow releases into our production environment. **This bug does not impact data quality or the current operation of the FAC.**
-
 ### What's next?
 
-We are currently working on [search](https://github.com/GSA-TTS/FAC/issues/2236). We have a version ready for release, but are unable to promote it to production due to underlying system issues. Search includes the ability to download PDFs, both via the website and API.
+We’ve released search, and will be continuing to make improvements. We’ll also be focusing on the migration of historical data, and doing some preparatory work to make future work easier.
 
-After releasing search, our priorities are:
+Our priorities are:
 - Adding the ability to add, remove, or change auditors and certifying officials who are attached to the audit.
 - Adding the ability to search for and download Tribal audits.
+- Adding the ability to bulk download search results.
 - Adding the ability to resubmit a previously submitted and completed audit.
 - Adding email notifications to alert auditees and auditors that a step is ready for them to complete.
-- Adding the ability to bulk download search results.
 
 ### Opportunities
 

--- a/src/resources/workbooks/federal-awards.md
+++ b/src/resources/workbooks/federal-awards.md
@@ -31,7 +31,7 @@ Enter the first two digits of the agency's ALN (formerly CFDA number).
 
 This field cannot be left blank.
 
-### Column C: ALN (formerly CFDA) Three Digit Extension**
+### Column C: ALN (formerly CFDA) Three Digit Extension
 
 Enter the last three digits of the agency's ALN.
 - For programs with no ALN or if the ALN is Unknown, enter a "U" followed by a two-digit number (e.g. U12) to identify one or more Federal award lines that form the program.

--- a/src/welcome.md
+++ b/src/welcome.md
@@ -11,7 +11,7 @@ include_survey: true
 
 The General Services Administration (GSA) launched the new Federal Audit Clearinghouse in October, 2023. All single audit submissions should now be submitted using [our new system](https://app.fac.gov/openid/login/). 
 
-For the time being, [search and download of historical audit data](https://facdissem.census.gov/Main.aspx) will remain on the Census' site.
+Users can also [search single audit reports](https://app.fac.gov/dissemination/search/) submitted to the FAC since October 1, 2023. For the time being, [search and download of historical audit data](https://facdissem.census.gov/Main.aspx) will remain on the Census' site.
 
 To help make this transition smooth, we've put together several resources for your use. In addition to being able to log in and complete the audit submission process, the new site includes:
 
@@ -22,4 +22,4 @@ To help make this transition smooth, we've put together several resources for yo
 
 ## For ACEE submitters
 
-At this time, the FAC is not accepting submissions for Alternative Compliance Examination Engagements (ACEE). The [Office of Management and Budget (OMB)]({{ config.baseUrl }}info/announcements) has granted an automatic extension for these entities for Audit Year 2023.
+At this time, the FAC is not accepting submissions for Alternative Compliance Examination Engagements (ACEE).


### PR DESCRIPTION
Made the following changes to the static site:

- Added the weekly update to [the FAC Updates page](https://federalist-35af9df5-a894-4ae9-aa3d-f6d95427c7bc.sites.pages.cloud.gov/preview/gsa-tts/fac-transition-site/lh/oct30-updates/info/updates/)
- Moved last week's update to [the Archive page](https://federalist-35af9df5-a894-4ae9-aa3d-f6d95427c7bc.sites.pages.cloud.gov/preview/gsa-tts/fac-transition-site/lh/oct30-updates/info/updates/archive/)
- Updated copy on [the Welcome page ](https://federalist-35af9df5-a894-4ae9-aa3d-f6d95427c7bc.sites.pages.cloud.gov/preview/gsa-tts/fac-transition-site/lh/oct30-updates/welcome/)to reflect the launch of Search
![Screenshot 2023-11-09 at 08-59-10 Welcome to the Federal Audit Clearinghouse](https://github.com/GSA-TTS/FAC-transition-site/assets/123114420/405b8840-08df-47a0-9048-22453fb2b101)
![Screenshot 2023-11-09 at 08-58-50 Archived updates from the FAC](https://github.com/GSA-TTS/FAC-transition-site/assets/123114420/1978025a-0090-4a5e-b19a-48cd086e9069)
![Screenshot 2023-11-09 at 08-58-41 Updates from the FAC](https://github.com/GSA-TTS/FAC-transition-site/assets/123114420/b5eaea30-1079-491e-a105-92d6c3eec897)
