### PR TITLE
Lh/search resources

### DIFF
--- a/src/_data/global.yaml
+++ b/src/_data/global.yaml
@@ -7,6 +7,8 @@ navigation:
       links: 
         - text: Search audits
           href: 'https://app.fac.gov/dissemination/search/'
+        - text: Resources
+          href: 'data/resources'
         - text: API
           href: 'developers'
     - text: Audit Submission

--- a/src/data/resources.md
+++ b/src/data/resources.md
@@ -34,7 +34,7 @@ Enter one UEI or EIN per line.
 
 > **Example**: If you enter only `RHVRCYWNTFX3`, the system will return a single audit for Clinton County. If you add a second line, and enter `UVLVR8CN2FM4`, the system will return two results, one for Clinton County and one for Santa Cruz County.
 
-### Assistance Listing Number (ALN/CFDA)
+### <a name=assistance-listing-number-alncfda></a>Assistance Listing Number (ALN/CFDA)
 
 The system supports search for both ALNs and for program numbers. Your list can contain a mix of both, or you can search for just one or the other.
 
@@ -46,7 +46,7 @@ Enter one number per line.
 
 > **Example**: If you enter `93` on one line, and `20.600` on another, the system will return all submissions that contained an award for HHS, and all awards that included funding on ALN 20.600. 
 
-### Name (entity, auditee, or auditor)
+### <a name=name-entity-auditee-or-auditor></a>Name (entity, auditee, or auditor)
 The name search looks at multiple fields in the single audit submission. At this time, the FAC matches whole words, not parts of words. The terms “school” and “schools” are not the same.
 
 The system ignores the capitalization of words. The terms “school,” “School,” and “SCHOOL” are all the same.
@@ -55,11 +55,11 @@ Enter one word per line.
 
 > **Example**: If  you are looking for a school, you might use the word “SCHOOL” as a part of your search. This will return “Ripley School District of Oklahoma,” but it will not return “Sand Creek Community Schools.” To get both, you would enter “SCHOOL” on one line, and “SCHOOLS” on the next. 
 
-### [Audit year](#audit-year)
+### <a name=audit-year></a>Audit year
 
 This filters on the submission’s audit year. If you leave it blank, the system will return results from all audit years; if you check one, it limits your results to the selected year(s) only. The migration of historical audits from Census to our system won’t happen until early 2024.
 
-### FAC acceptance date
+### <a name=fac-acceptance-date></a>FAC acceptance date
 
 Historically, this used to be FAC Release Date.  The current FAC system accepts and releases the single audit data immediately upon final submission by the auditee.
 
@@ -69,7 +69,7 @@ If you enter only a start date, the system wil lreturn all audits accepted after
 
 If you enter only an end date, the system will return all audits accepted before that date.
 
-### Cognizant or oversight
+### <a name=cognizant-or-oversight></a>Cognizant or oversight
 
 To filter by cognizant or oversight agency, you must select which you are looking for as well as enter the federal agency number. 
 

--- a/src/data/resources.md
+++ b/src/data/resources.md
@@ -26,7 +26,7 @@ The six filters currently available are:
 - [FAC acceptance date](#fac-acceptance-date)
 - [Cognizant or oversight](#cognizant-or-oversight)
 
-### [UEI or EIN](#uei-or-ein)
+### <a name=#uei-or-ein></a>UEI or EIN
 
 The FAC searches for all of the UEIs or EINS you enter; the system will ignore any that are incorrect.
 

--- a/src/data/resources.md
+++ b/src/data/resources.md
@@ -16,7 +16,7 @@ The FAC is coordinating access to Tribal data with agencies. That access will be
 
 The FAC search currently has six search filters that combine with each other to narrow down search results. It’s possible to combine filters and get no results.
 
-> **Example**: If you search a range of 8/1/2023 to 8/15/2023 for “FAC Release Date,”  plus a specific UEI, you won’t get any results because we didn’t collect or release any audits between August 1st and August 15th. Even if the UEI exists, this combination of filters won’t return any results.
+> **Example**: If you search a range of 8/1/2023 to 8/15/2023 for “FAC Release Date,”  plus a specific UEI, the system won’t return any results because we didn’t collect or release any audits between August 1st and August 15th. Even if the UEI exists, this combination of filters won’t return any results.
 
 The six filters currently available are:
 

--- a/src/data/resources.md
+++ b/src/data/resources.md
@@ -55,7 +55,7 @@ Enter one word per line.
 
 > **Example**: If  you are looking for a school, you might use the word “SCHOOL” as a part of your search. This will return “Ripley School District of Oklahoma,” but it will not return “Sand Creek Community Schools.” To get both, you would enter “SCHOOL” on one line, and “SCHOOLS” on the next. 
 
-### Audit year
+### [Audit year](#audit-year)
 
 This filters on the submission’s audit year. If you leave it blank, the system will return results from all audit years; if you check one, it limits your results to the selected year(s) only. The migration of historical audits from Census to our system won’t happen until early 2024.
 

--- a/src/data/resources.md
+++ b/src/data/resources.md
@@ -26,7 +26,7 @@ The six filters currently available are:
 - [FAC acceptance date](#fac-acceptance-date)
 - [Cognizant or oversight](#cognizant-or-oversight)
 
-### <a name=#uei-or-ein></a>UEI or EIN
+### <a name=#uei-or-ein>UEI or EIN</a>
 
 The FAC searches for all of the UEIs or EINS you enter; the system will ignore any that are incorrect.
 

--- a/src/data/resources.md
+++ b/src/data/resources.md
@@ -19,14 +19,14 @@ The FAC search currently has six search filters that combine with each other to 
 > **Example**: If you search a range of 8/1/2023 to 8/15/2023 for “FAC Release Date,”  plus a specific UEI, the system won’t return any results because we didn’t collect or release any audits between August 1st and August 15th. Even if the UEI exists, this combination of filters won’t return any results.
 
 The six filters currently available are:
-- [UEI or EIN](#uei-or-einuei)
+- [UEI or EIN](#uei)
 - [Assistance Listing Number (ALN/CFDA)](#assistance-listing-number-alncfda)
 - [Name (entity, auditee, or auditor)](#name-entity-auditee-or-auditor)
 - [Audit year](#audit-year)
 - [FAC acceptance date](#fac-acceptance-date)
 - [Cognizant or oversight](#cognizant-or-oversight)
 
-### UEI or EIN
+### UEI or EIN(#uei)
 
 The FAC searches for all of the UEIs or EINS you enter; the system will ignore any that are incorrect.
 

--- a/src/data/resources.md
+++ b/src/data/resources.md
@@ -19,14 +19,14 @@ The FAC search currently has six search filters that combine with each other to 
 > **Example**: If you search a range of 8/1/2023 to 8/15/2023 for “FAC Release Date,”  plus a specific UEI, the system won’t return any results because we didn’t collect or release any audits between August 1st and August 15th. Even if the UEI exists, this combination of filters won’t return any results.
 
 The six filters currently available are:
-- [UEI or EIN](#uei)
+- [UEI or EIN](#uei-or-ein)
 - [Assistance Listing Number (ALN/CFDA)](#assistance-listing-number-alncfda)
 - [Name (entity, auditee, or auditor)](#name-entity-auditee-or-auditor)
 - [Audit year](#audit-year)
 - [FAC acceptance date](#fac-acceptance-date)
 - [Cognizant or oversight](#cognizant-or-oversight)
 
-### [UEI or EIN](#uei)
+### [UEI or EIN](#uei-or-ein)
 
 The FAC searches for all of the UEIs or EINS you enter; the system will ignore any that are incorrect.
 

--- a/src/data/resources.md
+++ b/src/data/resources.md
@@ -16,56 +16,57 @@ The FAC is coordinating access to Tribal data with agencies. That access will be
 
 The FAC search currently has six search filters that combine with each other to narrow down search results. It’s possible to combine filters and get no results.
 
-> Example: If you search a range of 8/1/2023 to 8/15/2023 for “FAC Release Date,”  plus a specific UEI, you won’t get any results because we didn’t collect or release any audits between August 1st and August 15th. Even if the UEI exists, this combination of filters won’t return any results.
+> **Example**: If you search a range of 8/1/2023 to 8/15/2023 for “FAC Release Date,”  plus a specific UEI, you won’t get any results because we didn’t collect or release any audits between August 1st and August 15th. Even if the UEI exists, this combination of filters won’t return any results.
 
 The six filters currently available are:
 
 ### UEI or EIN
 
-The FAC searches for all of the UEIs or EINS that you enter; the system will ignore any that are incorrect.
+The FAC searches for all of the UEIs or EINS you enter; the system will ignore any that are incorrect.
 
 Enter one UEI or EIN per line.
 
-> Example: If you enter only `RHVRCYWNTFX3`, you will find a single audit for Clinton County. If you add a second line, and enter UVLVR8CN2FM4, you will get two results, one for Clinton County and one for Santa Cruz County.
+> **Example**: If you enter only `RHVRCYWNTFX3`, the system will return a single audit for Clinton County. If you add a second line, and enter `UVLVR8CN2FM4`, the system will return two results, one for Clinton County and one for Santa Cruz County.
 
 ### Assistance Listing Number (ALN/CFDA)
 
-We support search full both ALNs and for program numbers. Your list can contain a mix of both, or you can search for just one or the other.
+The system supports search for both ALNs and for program numbers. Your list can contain a mix of both, or you can search for just one or the other.
 
 Enter one number per line.
 
-> Example: If you enter the full ALN `93.778`, you will get back all audits that contained a federal award issued from agency number 93 (HHS), program 778 (Medical Assistance Program).
+> **Example**: If you enter the full ALN `93.778`, the system will return all audits that contained a federal award issued from agency number 93 (HHS), program 778 (Medical Assistance Program).
 
-> Example: If you enter `93`, you will get back all submissions that contained a federal award from agency number 93 (HHS).
+> **Example**: If you enter `93`, the system will return all submissions that contained a federal award from agency number 93 (HHS).
 
-> Example: If you enter `93` on one line, and `20.600` on another, you will get back all submissions that contained an award for HHS, and all awards that included funding on ALN 20.600. 
+> **Example**: If you enter `93` on one line, and `20.600` on another, the system will return all submissions that contained an award for HHS, and all awards that included funding on ALN 20.600. 
 
 ### Name (Entity, Auditee, or Auditor)
 The name search looks at multiple fields in the single audit submission. At this time, the FAC matches whole words, not parts of words. The terms “school” and “schools” are not the same.
 
-The search ignores the capitalization of words. The terms “school,” “School,” and “SCHOOL” are all the same.
+The system ignores the capitalization of words. The terms “school,” “School,” and “SCHOOL” are all the same.
 
 Enter one word per line.
 
-> Example: If  you are looking for a school, you might use the word “SCHOOL” as a part of your search. This will find “Ripley School District of Oklahoma,” but it will not find “Sand Creek Community Schools.” To find both, you would enter “SCHOOL” on one line, and “SCHOOLS” on the next. 
+> **Example**: If  you are looking for a school, you might use the word “SCHOOL” as a part of your search. This will return “Ripley School District of Oklahoma,” but it will not return “Sand Creek Community Schools.” To get both, you would enter “SCHOOL” on one line, and “SCHOOLS” on the next. 
 
 ### Audit year
 
-This filters on the submission’s audit year. If you leave it blank, you get all audit years; if you check one, it limits your results to the selected year(s) only. The migration of historical audits from Census to our system won’t happen until early 2024.
-FAC acceptance date
+This filters on the submission’s audit year. If you leave it blank, the system will return results from all audit years; if you check one, it limits your results to the selected year(s) only. The migration of historical audits from Census to our system won’t happen until early 2024.
+
+### FAC acceptance date
 
 Historically, this used to be FAC Release Date.  The current FAC system accepts and releases the single audit data immediately upon final submission by the auditee.
 
 This field filters by the date the FAC accepted an audit. You can enter both a start and end date to find audits accepted during a specific window or you can search by only start or end date.
 
-If you enter only a start date, you will get all audits accepted after that date.
+If you enter only a start date, the system wil lreturn all audits accepted after that date.
 
-If you enter only an end date, you will get all audits accepted before that date.
+If you enter only an end date, the system will return all audits accepted before that date.
 
 ### Cognizant or oversight
 
 To filter by cognizant or oversight agency, you must select which you are looking for as well as enter the federal agency number. 
 
-If you select cognizant or oversight but don’t enter an agency number, you won’t return any results. 
+If you select cognizant or oversight but don’t enter an agency number, the system won’t return any results. 
 
-If you enter an agency number but don’t select cognizant or oversight, you won’t return any results.
+If you enter an agency number but don’t select cognizant or oversight, the system won’t return any results.

--- a/src/data/resources.md
+++ b/src/data/resources.md
@@ -26,7 +26,7 @@ The six filters currently available are:
 - [FAC acceptance date](#fac-acceptance-date)
 - [Cognizant or oversight](#cognizant-or-oversight)
 
-### <a name=#uei-or-ein></a>UEI or EIN
+### <a name=uei-or-ein></a>UEI or EIN
 
 The FAC searches for all of the UEIs or EINS you enter; the system will ignore any that are incorrect.
 

--- a/src/data/resources.md
+++ b/src/data/resources.md
@@ -26,7 +26,7 @@ The six filters currently available are:
 - [FAC acceptance date](#fac-acceptance-date)
 - [Cognizant or oversight](#cognizant-or-oversight)
 
-### <a name=#uei-or-ein>UEI or EIN</a>
+### <a name=#uei-or-ein></a>UEI or EIN
 
 The FAC searches for all of the UEIs or EINS you enter; the system will ignore any that are incorrect.
 

--- a/src/data/resources.md
+++ b/src/data/resources.md
@@ -1,0 +1,71 @@
+---
+layout: home.njk
+title: FAC search resources
+meta:
+  name: FAC search resources
+  description: Find resources and instructions for searching single audit data.
+---
+
+# Search resources
+
+Single audit submissions accepted by the FAC are available for [search](https://app.fac.gov/dissemination/search/). This data is also available via the [FAC API]({{ config.baseUrl }}developers). 
+
+The FAC is coordinating access to Tribal data with agencies. That access will be available soon, and will be announced through [our updates page]({{ config.baseUrl }}info/updates).
+
+## Search filters
+
+The FAC search currently has six search filters that combine with each other to narrow down search results. It’s possible to combine filters and get no results.
+
+> Example: If you search a range of 8/1/2023 to 8/15/2023 for “FAC Release Date,”  plus a specific UEI, you won’t get any results because we didn’t collect or release any audits between August 1st and August 15th. Even if the UEI exists, this combination of filters won’t return any results.
+
+The six filters currently available are:
+
+### UEI or EIN
+
+The FAC searches for all of the UEIs or EINS that you enter; the system will ignore any that are incorrect.
+
+Enter one UEI or EIN per line.
+
+> Example: If you enter only `RHVRCYWNTFX3`, you will find a single audit for Clinton County. If you add a second line, and enter UVLVR8CN2FM4, you will get two results, one for Clinton County and one for Santa Cruz County.
+
+### Assistance Listing Number (ALN/CFDA)
+
+We support search full both ALNs and for program numbers. Your list can contain a mix of both, or you can search for just one or the other.
+
+Enter one number per line.
+
+> Example: If you enter the full ALN `93.778`, you will get back all audits that contained a federal award issued from agency number 93 (HHS), program 778 (Medical Assistance Program).
+
+> Example: If you enter `93`, you will get back all submissions that contained a federal award from agency number 93 (HHS).
+
+> Example: If you enter `93` on one line, and `20.600` on another, you will get back all submissions that contained an award for HHS, and all awards that included funding on ALN 20.600. 
+
+### Name (Entity, Auditee, or Auditor)
+The name search looks at multiple fields in the single audit submission. At this time, the FAC matches whole words, not parts of words. The terms “school” and “schools” are not the same.
+
+The search ignores the capitalization of words. The terms “school,” “School,” and “SCHOOL” are all the same.
+
+Enter one word per line.
+
+> Example: If  you are looking for a school, you might use the word “SCHOOL” as a part of your search. This will find “Ripley School District of Oklahoma,” but it will not find “Sand Creek Community Schools.” To find both, you would enter “SCHOOL” on one line, and “SCHOOLS” on the next. 
+
+### Audit year
+
+This filters on the submission’s audit year. If you leave it blank, you get all audit years; if you check one, it limits your results to the selected year(s) only. The migration of historical audits from Census to our system won’t happen until early 2024.
+FAC acceptance date
+
+Historically, this used to be FAC Release Date.  The current FAC system accepts and releases the single audit data immediately upon final submission by the auditee.
+
+This field filters by the date the FAC accepted an audit. You can enter both a start and end date to find audits accepted during a specific window or you can search by only start or end date.
+
+If you enter only a start date, you will get all audits accepted after that date.
+
+If you enter only an end date, you will get all audits accepted before that date.
+
+### Cognizant or oversight
+
+To filter by cognizant or oversight agency, you must select which you are looking for as well as enter the federal agency number. 
+
+If you select cognizant or oversight but don’t enter an agency number, you won’t return any results. 
+
+If you enter an agency number but don’t select cognizant or oversight, you won’t return any results.

--- a/src/data/resources.md
+++ b/src/data/resources.md
@@ -26,7 +26,7 @@ The six filters currently available are:
 - [FAC acceptance date](#fac-acceptance-date)
 - [Cognizant or oversight](#cognizant-or-oversight)
 
-### UEI or EIN(#uei)
+### [UEI or EIN](#uei)
 
 The FAC searches for all of the UEIs or EINS you enter; the system will ignore any that are incorrect.
 

--- a/src/data/resources.md
+++ b/src/data/resources.md
@@ -14,7 +14,7 @@ The FAC is coordinating access to Tribal data with agencies. That access will be
 
 ## Search filters
 
-The FAC search currently has six search filters that combine with each other to narrow down search results. It’s possible to combine filters and get no results.
+The FAC search currently has six search filters that combine with each other to narrow down search results. It’s possible to combine filters and not return any results.
 
 > **Example**: If you search a range of 8/1/2023 to 8/15/2023 for “FAC Release Date,”  plus a specific UEI, the system won’t return any results because we didn’t collect or release any audits between August 1st and August 15th. Even if the UEI exists, this combination of filters won’t return any results.
 
@@ -28,17 +28,17 @@ The six filters currently available are:
 
 ### <a name=uei-or-ein></a>UEI or EIN
 
-The FAC searches for all of the UEIs or EINS you enter; the system will ignore any that are incorrect.
-
 Enter one UEI or EIN per line.
+
+The FAC searches for all of the UEIs or EINS you enter; the system will ignore any that are incorrect.
 
 > **Example**: If you enter only `RHVRCYWNTFX3`, the system will return a single audit for Clinton County. If you add a second line, and enter `UVLVR8CN2FM4`, the system will return two results, one for Clinton County and one for Santa Cruz County.
 
 ### <a name=assistance-listing-number-alncfda></a>Assistance Listing Number (ALN/CFDA)
 
-The system supports search for both ALNs and for program numbers. Your list can contain a mix of both, or you can search for just one or the other.
-
 Enter one number per line.
+
+The system supports search for both ALNs and for program numbers. Your list can contain a mix of both, or you can search for just one or the other.
 
 > **Example**: If you enter the full ALN `93.778`, the system will return all audits that contained a federal award issued from agency number 93 (HHS), program 778 (Medical Assistance Program).
 
@@ -47,17 +47,18 @@ Enter one number per line.
 > **Example**: If you enter `93` on one line, and `20.600` on another, the system will return all submissions that contained an award for HHS, and all awards that included funding on ALN 20.600. 
 
 ### <a name=name-entity-auditee-or-auditor></a>Name (entity, auditee, or auditor)
+
+Enter one word per line.
+
 The name search looks at multiple fields in the single audit submission. At this time, the FAC matches whole words, not parts of words. The terms “school” and “schools” are not the same.
 
 The system ignores the capitalization of words. The terms “school,” “School,” and “SCHOOL” are all the same.
-
-Enter one word per line.
 
 > **Example**: If  you are looking for a school, you might use the word “SCHOOL” as a part of your search. This will return “Ripley School District of Oklahoma,” but it will not return “Sand Creek Community Schools.” To get both, you would enter “SCHOOL” on one line, and “SCHOOLS” on the next. 
 
 ### <a name=audit-year></a>Audit year
 
-This filters on the submission’s audit year. If you leave it blank, the system will return results from all audit years; if you check one, it limits your results to the selected year(s) only. The migration of historical audits from Census to our system won’t happen until early 2024.
+This filters on the submission’s audit year. If you leave it blank, the system will return results from all audit years; if you check one, it limits your results to the selected year(s) only. Historical audits from Census will be available in early 2024.
 
 ### <a name=fac-acceptance-date></a>FAC acceptance date
 
@@ -65,7 +66,7 @@ Historically, this used to be FAC Release Date.  The current FAC system accepts 
 
 This field filters by the date the FAC accepted an audit. You can enter both a start and end date to find audits accepted during a specific window or you can search by only start or end date.
 
-If you enter only a start date, the system wil lreturn all audits accepted after that date.
+If you enter only a start date, the system will return all audits accepted after that date.
 
 If you enter only an end date, the system will return all audits accepted before that date.
 

--- a/src/data/resources.md
+++ b/src/data/resources.md
@@ -19,6 +19,12 @@ The FAC search currently has six search filters that combine with each other to 
 > **Example**: If you search a range of 8/1/2023 to 8/15/2023 for “FAC Release Date,”  plus a specific UEI, the system won’t return any results because we didn’t collect or release any audits between August 1st and August 15th. Even if the UEI exists, this combination of filters won’t return any results.
 
 The six filters currently available are:
+- [UEI or EIN](#uei-or-einuei)
+- [Assistance Listing Number (ALN/CFDA)](#assistance-listing-number-alncfda)
+- [Name (entity, auditee, or auditor)](#name-entity-auditee-or-auditor)
+- [Audit year](#audit-year)
+- [FAC acceptance date](#fac-acceptance-date)
+- [Cognizant or oversight](#cognizant-or-oversight)
 
 ### UEI or EIN
 
@@ -40,7 +46,7 @@ Enter one number per line.
 
 > **Example**: If you enter `93` on one line, and `20.600` on another, the system will return all submissions that contained an award for HHS, and all awards that included funding on ALN 20.600. 
 
-### Name (Entity, Auditee, or Auditor)
+### Name (entity, auditee, or auditor)
 The name search looks at multiple fields in the single audit submission. At this time, the FAC matches whole words, not parts of words. The terms “school” and “schools” are not the same.
 
 The system ignores the capitalization of words. The terms “school,” “School,” and “SCHOOL” are all the same.


### PR DESCRIPTION
This PR adds a Search resources page to the static site. Changes include:

- creating [the new page](https://federalist-35af9df5-a894-4ae9-aa3d-f6d95427c7bc.sites.pages.cloud.gov/preview/gsa-tts/fac-transition-site/lh/search-resources/data/resources/#cognizant-or-oversight), including multiple crosslinks to other sections of the site
- adding "Resources" to the drop-down navigation under "Data"
![Screenshot 2023-11-14 at 11-40-00 FAC search resources](https://github.com/GSA-TTS/FAC-transition-site/assets/123114420/5c625c70-25a8-4b7d-81db-9b9f35e00992)
<img width="1242" alt="Screenshot 2023-11-14 at 11 40 12 AM" src="https://github.com/GSA-TTS/FAC-transition-site/assets/123114420/d8698513-1d64-4a61-aebe-b6a2fc025865">
