### PR TITLE
fixing direct award instructions in workbook 1

### DIFF
--- a/src/resources/workbooks/federal-awards.md
+++ b/src/resources/workbooks/federal-awards.md
@@ -113,9 +113,9 @@ If the award is not a loan or loan guarantee (column L is “N”), leave this f
 
 ### Column N: Direct Award
 
-Select "Y" if the award came directly from a Federal awarding agency and complete column O. 
+Select "Y" if the award came directly from a Federal awarding agency.  
 
-If it did not come directly from a Federal awarding agency, select "N".
+If it did not come directly from a Federal awarding agency, select "N" and complete column O.
 
 This field cannot be left blank.
 
@@ -123,7 +123,7 @@ This field cannot be left blank.
 
 If the award did not come directly from a Federal awarding agency, enter the name of the pass-through entity.
 
-This field cannot be left blank if Direct Award (column N) is “Y”.
+This field cannot be left blank if Direct Award (column N) is “N”.
 
 ### Column P: If no (Direct Award), Identifying Number Assigned by the Pass-through Entity, if assigned
 
@@ -131,7 +131,7 @@ If the award did not come directly from a Federal awarding agency, enter the ide
 
 If there is not an identifying number assigned by the pass-through entity, leave this field blank.
 
-This field cannot be blank if Direct Award (column N) is “Y”.
+This field cannot be blank if Direct Award (column N) is “N”.
 
 ### Column Q: Federal Award Passed Through to Subrecipients
 


### PR DESCRIPTION
This PR addresses the needed copy [updates to the workbook 1 instructions regarding passthrough awards](https://federalist-35af9df5-a894-4ae9-aa3d-f6d95427c7bc.sites.pages.cloud.gov/preview/gsa-tts/fac-transition-site/lh/fixing-2810/resources/workbooks/federal-awards/) per ticket [#2810](https://github.com/GSA-TTS/FAC/issues/2810).

<img width="956" alt="Screenshot 2024-01-04 at 8 32 17 AM" src="https://github.com/GSA-TTS/FAC-transition-site/assets/123114420/d609982b-3cd9-4deb-bf67-682f697fe6bd">
