### PR TITLE
Lh/updating user access

### DIFF
--- a/src/_collections/access/09-updated-roles.md
+++ b/src/_collections/access/09-updated-roles.md
@@ -4,4 +4,4 @@ title: Updated user roles
 image: user-access_09.png
 ---
 
-Once you’ve added new users, you will see their names and email addresses appear in the table of users on the single audit submission.
+Once you’ve added new users, you will see their names and email addresses appear in the table of users on the single audit submission. For the changes to take effect, **users must log out and back in to their account**.

--- a/src/_collections/access/09-updated-roles.md
+++ b/src/_collections/access/09-updated-roles.md
@@ -4,4 +4,4 @@ title: Updated user roles
 image: user-access_09.png
 ---
 
-Once you’ve added new users, you will see their names and email addresses appear in the table of users on the single audit submission. For the changes to take effect, **users must log out and back in to their account**.
+Once you’ve added new users, you will see their names and email addresses appear in the table of users on the single audit submission. **For the changes to take effect, users must log out and log back in to their account**.

--- a/src/resources/instructions/user-access.md
+++ b/src/resources/instructions/user-access.md
@@ -20,8 +20,7 @@ Anyone with access to the audit submission can make changes to the Auditee and A
 
 Keep in mind that you may only have one Auditee Certifying Official and Auditor Certifying Official per single audit submission. These may not be the same individuals.
 
-
-The instructions below walk you through making changes to user roles.
+The instructions below walk you through making changes to user roles. Once you have completed these steps, **users must log out and log back in to their account for the changes to take effect**.
 
 <ol>
 {% for item in collections.access %}


### PR DESCRIPTION
This PR adds copy explaining users will have to log out and log back in to see changes to their access on [the instructions page](https://federalist-35af9df5-a894-4ae9-aa3d-f6d95427c7bc.sites.pages.cloud.gov/preview/gsa-tts/fac-transition-site/lh/updating-user-access/resources/instructions/user-access/#updated-user-roles).

<img width="1024" alt="Screenshot 2024-01-04 at 9 16 22 AM" src="https://github.com/GSA-TTS/FAC-transition-site/assets/123114420/b69584db-7238-4985-ba6d-612bce4ecc0b">
<img width="985" alt="Screenshot 2024-01-04 at 9 16 15 AM" src="https://github.com/GSA-TTS/FAC-transition-site/assets/123114420/7edaac7e-46a9-409f-957b-605dd82a1482">
