### PR TITLE
fixing broken link to archived OMB announcements

### DIFF
--- a/src/info/announcements/index.md
+++ b/src/info/announcements/index.md
@@ -8,7 +8,7 @@ meta:
 
 # OMB Announcements
 
-The Office of Management and Budget (OMB) sets the policy for single audit submissions and their deadlines. The announcements below are in effect; for historic decisions, view [our archive]({{ config.baseUrl }}/info/announcements/archive).
+The Office of Management and Budget (OMB) sets the policy for single audit submissions and their deadlines. The announcements below are in effect; for historic decisions, view [our archive]({{ config.baseUrl }}info/announcements/archive).
 
 <div
   class="usa-summary-box"


### PR DESCRIPTION
This PR fixes a broken link on [the OMB Announcements page](https://federalist-35af9df5-a894-4ae9-aa3d-f6d95427c7bc.sites.pages.cloud.gov/preview/gsa-tts/fac-transition-site/lh/archive-linking/info/announcements/), making it possible to get to the archived announcements.

<img width="989" alt="Screenshot 2024-01-05 at 8 10 09 AM" src="https://github.com/GSA-TTS/FAC-transition-site/assets/123114420/2d9e5b38-71f3-4205-bc1d-bb03116d4497">
