### PR TITLE
Lh/copy updates

### DIFF
--- a/src/_collections/walkthrough/06-audit-access.md
+++ b/src/_collections/walkthrough/06-audit-access.md
@@ -6,7 +6,11 @@ image: walkthrough_06.png
 
 This is where you will list the auditee and auditor certifying officials, as well as anyone who will need to enter data or edit the single audit. Be sure to gather the names and email addresses of all individuals who will require access to the audit before proceeding with this step.
 
-Enter the email address for everyone who will need to edit the audit submission. You should include your email address as well.
+Enter the email address for everyone who will need to edit the audit submission. You should include your email address as well. Make sure these emaill addresses match the email addresses connected to the users' Login.gov accounts.
+
+If you need to make changes to users after creating the audit submission, you can find instructions on [our manage user access page]({{ config.baseUrl }}resources/instructions/user-access).
+
+The FAC doesn't notify users when they've been added to a submission. We recommend notifying them yourself.
 
 
 

--- a/src/_collections/walkthrough/06-audit-access.md
+++ b/src/_collections/walkthrough/06-audit-access.md
@@ -6,7 +6,7 @@ image: walkthrough_06.png
 
 This is where you will list the auditee and auditor certifying officials, as well as anyone who will need to enter data or edit the single audit. Be sure to gather the names and email addresses of all individuals who will require access to the audit before proceeding with this step.
 
-Enter the email address for everyone who will need to edit the audit submission. You should include your email address as well. Make sure these emaill addresses match the email addresses connected to the users' Login.gov accounts.
+Enter the email address for everyone who will need to edit the audit submission. You should include your email address as well. Make sure these email addresses match the email addresses connected to the users' Login.gov accounts.
 
 If you need to make changes to users after creating the audit submission, you can find instructions on [our manage user access page]({{ config.baseUrl }}resources/instructions/user-access).
 

--- a/src/_collections/walkthrough/12-tribal-data.md
+++ b/src/_collections/walkthrough/12-tribal-data.md
@@ -4,7 +4,7 @@ title: Tribal data release
 image: walkthrough_12.png
 ---
 
-Indian Tribes or Tribal Organizations will need to opt in or opt out of making their reporting package publicly available.
+Indian Tribes or Tribal Organizations will need to opt in or opt out of making their reporting package publicly available. This step must be completed by the Auditee Certifying Official.
 
 
 

--- a/src/_collections/walkthrough/12-tribal-data.md
+++ b/src/_collections/walkthrough/12-tribal-data.md
@@ -4,7 +4,7 @@ title: Tribal data release
 image: walkthrough_12.png
 ---
 
-Indian Tribes or Tribal Organizations will need to opt in or opt out of making their reporting package publicly available. This step must be completed by the Auditee Certifying Official.
+Indian Tribes or Tribal Organizations will need to opt in or opt out of making their reporting package publicly available. **This step must be completed by the Auditee Certifying Official.**
 
 
 

--- a/src/_collections/walkthrough/14-lock.md
+++ b/src/_collections/walkthrough/14-lock.md
@@ -8,8 +8,6 @@ After validation, you will lock your single audit submission for certification.
 
 If you need to make edits after this step, you may unlock your submission from the audit status page. Before certification, you will have to re-validate and re-lock your data.
 
-Make sure you save copies of your documents to your local drive before moving on to certification as **the FAC does not maintain versions for you**.
-
 
 
 

--- a/src/_collections/walkthrough/16-confirmation.md
+++ b/src/_collections/walkthrough/16-confirmation.md
@@ -4,6 +4,6 @@ title: Confirming submission
 image: walkthrough_16.png
 ---
 
-The submission process is complete.
+Once you submit your single audit package, you can't make any further changes. What you have submitted is what will be available via the FAC's audit search.
 
 We recommend you save a copy your audit materials on your local machine. If you need to resubmit, having the originals will make the process much easier.


### PR DESCRIPTION
This covers minor copy updates to[ the submission instructions page](https://federalist-35af9df5-a894-4ae9-aa3d-f6d95427c7bc.sites.pages.cloud.gov/preview/gsa-tts/fac-transition-site/lh/copy-updates/resources/instructions/):

- Linking to the manage user access page
- Clarifying the FAC does not send email notifications to users added to submissions
- Clarifying that the Tribal data release step must be completed by the Auditee Certifying Official
- Clarifying that submission is final and no changes may be made afterwards

<img width="929" alt="Screenshot 2024-01-11 at 10 24 21 AM" src="https://github.com/GSA-TTS/FAC-transition-site/assets/123114420/ad07bc29-46d0-4ef2-b786-12fd196ce5d9">
<img width="929" alt="Screenshot 2024-01-11 at 10 26 52 AM" src="https://github.com/GSA-TTS/FAC-transition-site/assets/123114420/b25b75d9-a1de-4799-87cb-ace0fa69a480">
<img width="937" alt="Screenshot 2024-01-11 at 10 25 34 AM" src="https://github.com/GSA-TTS/FAC-transition-site/assets/123114420/24f3c5e6-3e7e-4d93-941c-1946cf7d99ee">

