### PR TITLE
Add details about prefix and ALN requirements

### DIFF
--- a/src/resources/workbooks/federal-awards.md
+++ b/src/resources/workbooks/federal-awards.md
@@ -54,8 +54,9 @@ If you entered a valid ALN Three Digit Extension in column C, leave this field b
 
 ### Column E: Federal Program Name
 
-Select the name of the Federal program from the drop-down list provided. 
+Select the name of the Federal program from the drop-down list provided.
 
+- If the drop-down list is empty, you may need to enter a Federal Agency Prefix and ALN in columns B and C.
 - If the program is not present in the list, look up your ALN on [SAM.gov](https://sam.gov/content/assistance-listings) and attempt to find the authoritative program name for your award.
 - If you cannot find an authoritative program name, enter a name recognizable by the Federal awarding agency or pass-through entity.
 


### PR DESCRIPTION
Following a conversation with @alyssamwong, this PR adds a bullet to the "Federal Program Name" section of the federal awards workbook doc. The program name drop-down will only be populated if the workbook can find a matching `prefix.ALN` program number.

As a companion to this update, we should probably update the data validation error message that pops up in excel if you type an invalid name into column E. 