### PR TITLE
fixing errors in workbook instructions

### DIFF
--- a/src/resources/workbooks/federal-awards-audit-findings.md
+++ b/src/resources/workbooks/federal-awards-audit-findings.md
@@ -27,7 +27,7 @@ Enter the award reference number as listed in SF-SAC Section 1: Federal Awards. 
 
 ### Column B: Audit Finding Reference Number
 
-Enter the audit finding reference number as listed in F-SAC Section 1: Federal Awards. Audit finding reference numbers must be formatted “YYYY-###”.
+Enter the audit finding reference number as listed in SF-SAC Section 1: Federal Awards. Audit finding reference numbers must be formatted “YYYY-###”.
 
 ### Column C: Type(s) of Compliance Requirement(s)
 

--- a/src/resources/workbooks/federal-awards.md
+++ b/src/resources/workbooks/federal-awards.md
@@ -124,9 +124,9 @@ This field can't be left blank.
 
 ### Column O: If no (Direct Award), Name of Passthrough Entity
 
-If column N is "Y". this field can't be left blank. You must enter the name of your pass-through entity.
+If column N is "N". this field can't be left blank. You must enter the name of your pass-through entity.
 
-If column N is "N", you must leave this field blank.
+If column N is "Y", you must leave this field blank.
 
 ### Column P: If no (Direct Award), Identifying Number Assigned by the Pass-through Entity, if assigned
 


### PR DESCRIPTION
This PR fixes errors in the workbook instructions per tickets [#3469 ](https://github.com/GSA-TTS/FAC/issues/3469)and [#3460](https://github.com/GSA-TTS/FAC/issues/3460). Specifically, these are for the instructions on [workbook 1](https://federalist-35af9df5-a894-4ae9-aa3d-f6d95427c7bc.sites.pages.cloud.gov/preview/gsa-tts/fac-transition-site/lh/mar1-updates/resources/workbooks/federal-awards/) and [3](https://federalist-35af9df5-a894-4ae9-aa3d-f6d95427c7bc.sites.pages.cloud.gov/preview/gsa-tts/fac-transition-site/lh/mar1-updates/resources/workbooks/federal-awards-audit-findings/).

![Screenshot 2024-03-01 at 1 19 25 PM](https://github.com/GSA-TTS/FAC-transition-site/assets/123114420/2f24091d-7485-4fec-98c1-01afe84dbc86)
![Screenshot 2024-03-01 at 1 19 16 PM](https://github.com/GSA-TTS/FAC-transition-site/assets/123114420/c186cc8c-8250-4132-bb07-5e2206ed3cbb)
