### PR TITLE
Suggestions for increased transparency

### DIFF
--- a/src/status.md
+++ b/src/status.md
@@ -15,6 +15,8 @@ We're aware that search performance, even reduced to UEI-only, continues to be s
 
 We are also exploring options for using the API to generate a static list of submitted reports for use by audit resolution officials. We'll post more on this page if this becomes available.
 
+For specific questions or issues, please contact the FAC via [our helpdesk](https://support.fac.gov/hc/en-us/requests/new).
+
 ## March 18, 2024
 
 **Audit search is currently limited to UEI-only.** You can search your UEI to confirm your audit submission is complete. The PDF report is still be available for download but summary report workbooks aren't.

--- a/src/status.md
+++ b/src/status.md
@@ -11,7 +11,21 @@ meta:
 **Audit search is currently limited to UEI-only.** You can search your UEI to confirm your audit submission is complete. The PDF report will still be available for download but summary report workbooks won't.
 
 ## Issue background
-In mid-February, GSA completed the migration of historical data from the Census Bureau. This increased the amount of data in the GSA system exponentially and slowed down search performance.
-Our team has released multiple patches to stabilize search performance since then but have been unable to do so consistently. For this reason, we've decided to reduce search to UEI-only while we focus on building new search tables instead of one-off bug fixes.
 
-We're working as quickly and efficiently as possible to return full search functionality to our users as soon as we can. Thank you for your patience.
+On February 7th, GSA completed the migration of historical data from the Census Bureau. This increased the amount of data in the GSA system more than twenty-fold, drastically impairing search performance.
+
+Our team has taken incremental, iterative steps to improve search performance since then but have been unable to do so in a manner that addresses the multiple challenges at hand. For this reason, we've decided to reduce search to UEI-only while we focus on building the infrastructure necessary to support a more sustainable search experience.
+
+We're working as quickly as possible to return full search functionality to our users as soon as we can. We recognize the significant disruption this represents to users with oversight responsibilities, and will provide daily updates here until this issue is resolved.
+
+A brief history of our efforts:
+
+1. February 7th, data from Census is completely loaded, increasing the number of audits from 10K to more than 250K, and the number of awards tracked from 100K to nearly 4.5M.
+2. February 8th, [resources increased in production](https://github.com/GSA-TTS/FAC/pull/3376) to address load. 
+3. February 9th, [My ALN](https://github.com/GSA-TTS/FAC/pull/3378) functionality is removed in an attempt to address crashing behaviors stemming from this feature.
+4. February 14th, worked with more than a dozen NSACs to [prioritize search needs](https://github.com/GSA-TTS/FAC/issues/3388). 
+5. February 16th, [increased search capacity in production](https://github.com/GSA-TTS/FAC/pull/3424).
+6. February 28th, [added prioritized search needs](https://github.com/GSA-TTS/FAC/pull/3440), re-introducing performance challenges.
+7. March 11th, heavy system load prevents system updates for nearly a week. [Post-workday update to increase resources in production](https://github.com/GSA-TTS/FAC/pull/3496) carried out, partially addressing new search performance challenges.
+8. March 14th, performance issues and crashing persist in search. [New search tables and queries introduced](https://github.com/GSA-TTS/FAC/pull/3511). Changes require significant engineering and testing work. 
+9. March 18th, decision to take down search made by team.

--- a/src/status.md
+++ b/src/status.md
@@ -16,7 +16,7 @@ On February 7th, GSA completed the migration of historical data from the Census 
 
 Our team has taken incremental, iterative steps to improve search performance since then but has been unable to quickly address the multiple challenges at hand. For this reason, we've decided to reduce search to UEI-only while we focus on building the infrastructure necessary to support a more sustainable search experience. A UEI-only search allows auditors and auditees to verify that their submissions are complete.
 
-We're working as quickly as possible to return full search functionality as soon as we can. We recognize the significant disruption this represents to users with oversight responsibilities, and will provide daily updates here until this issue is resolved.
+We're working hard to return full search functionality as soon as possible. We recognize the significant disruption this represents to users with oversight responsibilities, and will provide daily updates here until this issue is resolved.
 
 A brief history of our efforts:
 

--- a/src/status.md
+++ b/src/status.md
@@ -5,27 +5,38 @@ meta:
   name: FAC system status
   description: Track the operating status of the FAC, both for audit submission and search.
 ---
+# FAC system status
 
-# March 18, 2024
+This page tracks the operating status of the FAC, both for audit submission and search.
 
-**Audit search is currently limited to UEI-only.** You can search your UEI to confirm your audit submission is complete. The PDF report will still be available for download but summary report workbooks won't.
+## March 18, 2024
 
-## Issue background
+**Audit search is currently limited to UEI-only.** You can search your UEI to confirm your audit submission is complete. The PDF report is still be available for download but summary report workbooks aren't.
 
-On February 7th, GSA completed the migration of historical data from the Census Bureau. This increased the amount of data in the GSA system more than twenty-fold, drastically impairing search performance.
+### Issue background
 
-Our team has taken incremental, iterative steps to improve search performance since then but has been unable to quickly address the multiple challenges at hand. For this reason, we've decided to reduce search to UEI-only while we focus on building the infrastructure necessary to support a more sustainable search experience. A UEI-only search allows auditors and auditees to verify that their submissions are complete.
+In mid-February, GSA completed the migration of historical data from the Census Bureau. This increased the amount of data in the GSA system exponentially, hindering search performance. 
 
-We're working hard to return full search functionality as soon as possible. We recognize the significant disruption this represents to users with oversight responsibilities, and will provide daily updates here until this issue is resolved.
+Over the last month, our team has released multiple patches to stabilize search with limited success. Because of this, we've reduced search to UEI-only while we focus on building a more sustainable search function.
 
-A brief history of our efforts:
+We're working hard to return full search functionality as soon as we can. We know this is a significant disruption for many users. Thank you for your patience.
 
-1. February 7th, data from Census is completely loaded, increasing the number of audits from 10K to more than 250K, and the number of awards tracked from 100K to nearly 4.5M.
-2. February 8th, [resources increased in production](https://github.com/GSA-TTS/FAC/pull/3376) to address load. 
-3. February 9th, [My ALN](https://github.com/GSA-TTS/FAC/pull/3378) functionality is removed in an attempt to address crashing behaviors stemming from this feature.
-4. February 14th, worked with more than a dozen NSACs to [prioritize search needs](https://github.com/GSA-TTS/FAC/issues/3388). 
-5. February 16th, [increased search capacity in production](https://github.com/GSA-TTS/FAC/pull/3424).
-6. February 28th, [added prioritized search needs](https://github.com/GSA-TTS/FAC/pull/3440), re-introducing performance challenges.
-7. March 11th, heavy system load prevents system updates for nearly a week. [Post-workday update to increase resources in production](https://github.com/GSA-TTS/FAC/pull/3496) carried out, partially addressing new search performance challenges.
-8. March 14th, performance issues and crashing persist in search. [New search tables and queries introduced](https://github.com/GSA-TTS/FAC/pull/3511). Changes require significant engineering and testing work. 
-9. March 18th, decision to take down search made by team.
+**A timeline of the issues:**
+
+- February 7: We completed the data migration. This increased the number of audits from 10K to more than 250K, and the number of awards tracked from 100K to nearly 4.5M.
+
+- February 8: We [increased resources in our production environment](https://github.com/GSA-TTS/FAC/pull/3376) to address the increased load.
+
+- February 9: The team removed the [My ALN filter](https://github.com/GSA-TTS/FAC/pull/3378) in an attempt to stop system crashes caused by this feature.
+
+- February 14: We worked with more than a dozen NSACs to [prioritize search needs](https://github.com/GSA-TTS/FAC/issues/3388).
+
+- February 16: The team [increased search capacity in the production environment](https://github.com/GSA-TTS/FAC/pull/3424).
+
+- February 28: We [added prioritized search needs](https://github.com/GSA-TTS/FAC/pull/3440), re-introducing performance challenges.
+
+- March 11:  Heavy use of the system prevented system updates for nearly a week. The team completed [an after-hours update to the production environment](https://github.com/GSA-TTS/FAC/pull/3496), partially addressing new search performance issues.
+
+- March 14: Performance issues and system crashes persisted in search. The team released [new search tables and queries](https://github.com/GSA-TTS/FAC/pull/3511). These required significant engineering and testing work.
+
+- March 18: The team decided to take down search to focus on long-term solutions vs. short-term patches.

--- a/src/status.md
+++ b/src/status.md
@@ -14,9 +14,9 @@ meta:
 
 On February 7th, GSA completed the migration of historical data from the Census Bureau. This increased the amount of data in the GSA system more than twenty-fold, drastically impairing search performance.
 
-Our team has taken incremental, iterative steps to improve search performance since then but have been unable to do so in a manner that addresses the multiple challenges at hand. For this reason, we've decided to reduce search to UEI-only while we focus on building the infrastructure necessary to support a more sustainable search experience.
+Our team has taken incremental, iterative steps to improve search performance since then but has been unable to quickly address the multiple challenges at hand. For this reason, we've decided to reduce search to UEI-only while we focus on building the infrastructure necessary to support a more sustainable search experience. A UEI-only search allows auditors and auditees to verify that their submissions are complete.
 
-We're working as quickly as possible to return full search functionality to our users as soon as we can. We recognize the significant disruption this represents to users with oversight responsibilities, and will provide daily updates here until this issue is resolved.
+We're working as quickly as possible to return full search functionality as soon as we can. We recognize the significant disruption this represents to users with oversight responsibilities, and will provide daily updates here until this issue is resolved.
 
 A brief history of our efforts:
 

--- a/src/status.md
+++ b/src/status.md
@@ -9,6 +9,12 @@ meta:
 
 This page tracks the operating status of the FAC, both for audit submission and search.
 
+## March 19
+
+We're aware that search performance, even reduced to UEI-only, continues to be slow. Our engineers are investigating the root cause of the issue and continue to work on a solution. 
+
+We are also exploring options for using the API to generate a static list of submitted reports for use by audit resolution officials. We'll post more on this page if this becomes available.
+
 ## March 18, 2024
 
 **Audit search is currently limited to UEI-only.** You can search your UEI to confirm your audit submission is complete. The PDF report is still be available for download but summary report workbooks aren't.


### PR DESCRIPTION
This PR suggests some text changes to the copy, and adds back a chronology.

Because our site is used by:

1. Auditors and auditees submitting audits
2. State auditors (and other entities) responsible for passthrough monitoring
3. Federal audit resolution officials
4. IG offices
5. Grants managers/grants issuing offices
6. GAO
8. OMB
9. The general public
10. ...

I think credibility is enhanced by transparency, and because we have a public record of our efforts in this space (our Github repository), I think we should use it to document the actions we've taken so far.

For consideration.