### PR TITLE
Lh/march 25 updates search no

### DIFF
--- a/src/status/index.md
+++ b/src/status/index.md
@@ -9,6 +9,14 @@ meta:
 
 This page tracks the operating status of the FAC, both for audit submission and search.
 
+## March 25, 2024
+
+During testing for the improved search, our engineering team found a bug in the audit submission process. We're a small team and had to divert resources from search to fixing this issue. Once that bug is resolved, we'll return our attention to search.
+
+We are continuing to upload [static lists of submitted reports]({{ config.baseUrl }}status/findings) daily for audit resoluiton officials.
+
+If you have questions about search or the audit resolution lists, please [contact the FAC helpdesk](https://support.fac.gov/hc/en-us/requests/new)
+
 ## March 22, 2024
 
 Our engineering team continues to test the new infrastructure supporting search. 

--- a/src/status/index.md
+++ b/src/status/index.md
@@ -15,7 +15,7 @@ During testing for the improved search, our engineering team found a bug in the 
 
 We are continuing to upload [static lists of submitted reports]({{ config.baseUrl }}status/findings) daily for audit resoluiton officials.
 
-If you have questions about search or the audit resolution lists, please [contact the FAC helpdesk](https://support.fac.gov/hc/en-us/requests/new)
+If you have questions about search or the audit resolution lists, please [contact the FAC helpdesk](https://support.fac.gov/hc/en-us/requests/new).
 
 ## March 22, 2024
 
@@ -23,7 +23,7 @@ Our engineering team continues to test the new infrastructure supporting search.
 
 We are continuing to upload [static lists of submitted reports]({{ config.baseUrl }}status/findings) daily for audit resoluiton officials.
 
-If you have questions about search or the audit resolution lists, please [contact the FAC helpdesk](https://support.fac.gov/hc/en-us/requests/new)
+If you have questions about search or the audit resolution lists, please [contact the FAC helpdesk](https://support.fac.gov/hc/en-us/requests/new).
 
 ## March 21, 2024
 
@@ -33,7 +33,7 @@ Again, we want to caution users that you will experience slow load times. We exp
 
 We now have [static lists of submitted reports available]({{ config.baseUrl }}status/findings). These exports list all audits with awards findings submitted by date.
 
-If you have questions about search or the audit resolution lists, please [contact the FAC helpdesk](https://support.fac.gov/hc/en-us/requests/new)
+If you have questions about search or the audit resolution lists, please [contact the FAC helpdesk](https://support.fac.gov/hc/en-us/requests/new).
 
 ## March 20, 2024
 


### PR DESCRIPTION
This is the March 25 update for [the site status page](https://federalist-35af9df5-a894-4ae9-aa3d-f6d95427c7bc.sites.pages.cloud.gov/preview/gsa-tts/fac-transition-site/lh/march-25-updates-search-no/status/), written to reflect Search still being **unavailable**.

![Screenshot 2024-03-25 at 3 22 51 PM](https://github.com/GSA-TTS/FAC-transition-site/assets/123114420/f73fcbd0-e458-4f0f-8d77-31c0e64ed68d)
