### PR TITLE
Lh/march 26 status

### DIFF
--- a/src/status/findings.md
+++ b/src/status/findings.md
@@ -8,7 +8,7 @@ meta:
 
 # FAC findings updates
 
-Because the FAC search is currently limited to UEI-only, we'll be providing a daily export of new submissions with findings. These workbooks will provide a summary of audits with findings submitted each day. **Audits without findings aren't included.**
+While users transition to our updated Search interface, we'll be providing a daily export of new submissions with findings. These workbooks will provide a summary of audits with findings submitted each day. **Audits without findings aren't included.**
 
 We'll continue to upload these exports daily until April 16, 2024.
 

--- a/src/status/findings.md
+++ b/src/status/findings.md
@@ -10,7 +10,7 @@ meta:
 
 Because the FAC search is currently limited to UEI-only, we'll be providing a daily export of new submissions with findings. These workbooks will provide a summary of audits with findings submitted each day. **Audits without findings aren't included.**
 
-If you need additional fields, please [contact the FAC helpdesk](https://support.fac.gov/hc/en-us/requests/new).
+We'll continue to upload these exports daily until April 16, 2024.
 
 ## About the workbooks
 

--- a/src/status/index.md
+++ b/src/status/index.md
@@ -14,7 +14,7 @@ The FAC is operating normally.
 We'll continue to upload [static lists of submitted reports]({{ config.baseUrl }}status/findings) daily for audit resolution officials until April 16, 2024.
 
 <div class="usa-accordion usa-accordion--bordered">
-<h4 class="usa-accordion__heading">
+<h2 class="usa-accordion__heading">
   <button
     type="button"
     class="usa-accordion__button"
@@ -23,10 +23,10 @@ We'll continue to upload [static lists of submitted reports]({{ config.baseUrl }
   >
     FAC Search Disruption March 2024
   </button>
-</h4>
+</h2>
 <div id="b-feb5" class="usa-accordion__content usa-prose">
 
-## March 25, 2024
+### March 25, 2024
 
 [Search](https://app.fac.gov/dissemination/search/) is now fully restored and available for users. We split search functionality into two pages:
 
@@ -35,7 +35,7 @@ We'll continue to upload [static lists of submitted reports]({{ config.baseUrl }
 
 If you have questions about search, please [contact the FAC helpdesk.](https://support.fac.gov/hc/en-us/requests/new)
 
-## March 22, 2024
+### March 22, 2024
 
 Our engineering team continues to test the new infrastructure supporting search. 
 
@@ -43,7 +43,7 @@ We are continuing to upload [static lists of submitted reports]({{ config.baseUr
 
 If you have questions about search or the audit resolution lists, please [contact the FAC helpdesk](https://support.fac.gov/hc/en-us/requests/new).
 
-## March 21, 2024
+### March 21, 2024
 
 Testing of the new search infrastructure is still underway but our engineering team is making progress. We expect to turn search back on by early next week.
 
@@ -53,7 +53,7 @@ We now have [static lists of submitted reports available]({{ config.baseUrl }}st
 
 If you have questions about search or the audit resolution lists, please [contact the FAC helpdesk](https://support.fac.gov/hc/en-us/requests/new).
 
-## March 20, 2024
+### March 20, 2024
 
 Our engineering team has made progress on improving search stability and performance. We'll be turning back on all search filters for testing soon. During this testing period, we want to caution users that **you will experience slow load times**. We expect searches using multiple filters to take several minutes. 
 
@@ -61,7 +61,7 @@ If you experience a system error message, please [contact the FAC helpdesk](http
 
 We're also continuing to work on a static list of submitted reports for use by audit resolution officials.
 
-## March 19, 2024
+### March 19, 2024
 
 We're aware that search performance, even reduced to UEI-only, continues to be slow. Our engineers are investigating the root cause of the issue and continue to work on a solution. 
 
@@ -69,11 +69,11 @@ We are also exploring options for using the API to generate a static list of sub
 
 For specific questions or issues, please contact the FAC via [our helpdesk](https://support.fac.gov/hc/en-us/requests/new).
 
-## March 18, 2024
+### March 18, 2024
 
 **Audit search is currently limited to UEI-only.** You can search your UEI to confirm your audit submission is complete. The PDF report is still be available for download but summary report workbooks aren't.
 
-### Issue background
+#### Issue background
 
 In mid-February, GSA completed the migration of historical data from the Census Bureau. This increased the amount of data in the GSA system exponentially, hindering search performance. 
 

--- a/src/status/index.md
+++ b/src/status/index.md
@@ -9,6 +9,23 @@ meta:
 
 This page tracks the operating status of the FAC, both for audit submission and search.
 
+The FAC is operating normally.
+
+We'll continue to upload [static lists of submitted reports]({{ config.baseUrl }}status/findings) daily for audit resolution officials until April 16, 2024.
+
+<div class="usa-accordion usa-accordion--bordered">
+<h4 class="usa-accordion__heading">
+  <button
+    type="button"
+    class="usa-accordion__button"
+    aria-expanded="true"
+    aria-controls="b-feb5"
+  >
+    FAC Search Disruption March 2024
+  </button>
+</h4>
+<div id="b-feb5" class="usa-accordion__content usa-prose">
+
 ## March 25, 2024
 
 [Search](https://app.fac.gov/dissemination/search/) is now fully restored and available for users. We split search functionality into two pages:
@@ -83,3 +100,5 @@ We're working hard to return full search functionality as soon as we can. We kno
 - March 14: Performance issues and system crashes persisted in search. The team released [new search tables and queries](https://github.com/GSA-TTS/FAC/pull/3511). These required significant engineering and testing work.
 
 - March 18: The team decided to take down search to focus on long-term solutions vs. short-term patches.
+
+</div>


### PR DESCRIPTION
This PR covers the daily status update for March 26, including new copy on [the status page](https://federalist-35af9df5-a894-4ae9-aa3d-f6d95427c7bc.sites.pages.cloud.gov/preview/gsa-tts/fac-transition-site/lh/march-26-status/status/), moving the previous updates into an accordion, and then updating [the Findings page](https://federalist-35af9df5-a894-4ae9-aa3d-f6d95427c7bc.sites.pages.cloud.gov/preview/gsa-tts/fac-transition-site/lh/march-26-status/status/findings/) to say we'll be stopping on April 16. 

<img width="1052" alt="Screenshot 2024-03-26 at 2 31 05 PM" src="https://github.com/GSA-TTS/FAC-transition-site/assets/123114420/952603f4-553f-46be-94b8-34af5478cecd">
<img width="1014" alt="Screenshot 2024-03-26 at 2 30 50 PM" src="https://github.com/GSA-TTS/FAC-transition-site/assets/123114420/e67a348a-639f-4f65-9207-a51efc7aa5cc">
