### PR TITLE
adding submission deadline banner

### DIFF
--- a/src/_includes/header.njk
+++ b/src/_includes/header.njk
@@ -1,6 +1,15 @@
 <div class="usa-overlay"></div>
 <header class="usa-header usa-header--extended">
     
+<div class="usa-alert usa-alert--info">
+  <div class="usa-alert__body">
+    <h4 class="usa-alert__heading">Submission deadline</h4>
+    <p class="usa-alert__text">
+      Audits due on March 31, 2024 have until midnight on April, 1, 2024 to be submitted without penalty.
+    </p>
+  </div>
+</div>
+
     <div class="usa-navbar">
             <div class="usa-logo" id="basic-logo">
                 <a class="usa-logo-link" href="{{ config.baseUrl }}">


### PR DESCRIPTION
This PR adds an informational banner to [the static site](https://federalist-35af9df5-a894-4ae9-aa3d-f6d95427c7bc.sites.pages.cloud.gov/preview/gsa-tts/fac-transition-site/lh/weekend-coverage-banner/) letting users know about the April 1st submission deadline.

![Screenshot 2024-03-27 at 2 48 58 PM](https://github.com/GSA-TTS/FAC-transition-site/assets/123114420/4c851195-d340-44bb-99cc-f25ff3a3415c)
