### PR TITLE
adding submission home to nav

### DIFF
--- a/src/_data/global.yaml
+++ b/src/_data/global.yaml
@@ -16,6 +16,8 @@ navigation:
       links:
         - text: Submission resources
           href: 'audit-resources'
+        - text: Submission home
+          href: https://app.fac.gov/openid/login/
     - text: Updates & News
       id: news
       links:


### PR DESCRIPTION
This PR adds [a new option to the Audit submission dropdown](https://federalist-35af9df5-a894-4ae9-aa3d-f6d95427c7bc.sites.pages.cloud.gov/preview/gsa-tts/fac-transition-site/lh/nav-testing/) in the navigation per user feedback and makes it possible to get to "Submission home" from the navigation.

<img width="1009" alt="Screenshot 2024-04-18 at 9 40 07 AM" src="https://github.com/GSA-TTS/FAC-transition-site/assets/123114420/f94e6b06-f5cb-443f-bf12-8d1d3b1c6d4b">
