### PR TITLE
Add search.gov and googletagmanager to script-src CSP

### DIFF
--- a/src/_includes/layout.njk
+++ b/src/_includes/layout.njk
@@ -5,7 +5,7 @@
         <meta charset="UTF-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://touchpoints.app.cloud.gov https://dap.digitalgov.gov https://www.google-analytics.com; img-src 'self' https://touchpoints.app.cloud.gov; style-src 'self' 'unsafe-inline'; object-src 'none'; worker-src 'none'; connect-src https://www.google-analytics.com;">
+        <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://dap.digitalgov.gov https://www.google-analytics.com https://www.googletagmanager.com https://search.usa.gov https://touchpoints.app.cloud.gov; img-src 'self' https://touchpoints.app.cloud.gov; style-src 'self' 'unsafe-inline'; object-src 'none'; worker-src 'none'; connect-src https://www.google-analytics.com;">
         <meta name="{{meta.name}}" description="{{meta.description}}">
         <link rel="icon" type="image/x-icon" href="{{ config.baseUrl }}assets/img/favicons/icon_logo.svg" />
         <link rel="stylesheet" href="{{ config.baseUrl }}assets/css/styles.css" media="all" type="text/css">


### PR DESCRIPTION
This PR adds search.gov and googletagmanager to the static site's CSP `script-src` list, which should fix the failed DAP loader.

See https://github.com/GSA-TTS/FAC/issues/2813 for more

## How to test

If you go to a [preview page for this PR](https://federalist-35af9df5-a894-4ae9-aa3d-f6d95427c7bc.sites.pages.cloud.gov/preview/gsa-tts/fac-transition-site/ds/search-ga-csp/audit-resources/) and open your browser's network inspector, you should see some successful POST requests to GA's `collect` endpoint. 

If you go to a [preview page for an older PR](https://federalist-35af9df5-a894-4ae9-aa3d-f6d95427c7bc.sites.pages.cloud.gov/preview/gsa-tts/fac-transition-site/lh/search-updates/audit-resources/) and do the same, you should see two failed requests to load scripts from search.gov and googletagmanager.com. 