### PR TITLE
removing link to search results on status page

### DIFF
--- a/src/status/index.md
+++ b/src/status/index.md
@@ -11,8 +11,6 @@ This page tracks the operating status of the FAC, both for audit submission and 
 
 The FAC is operating normally.
 
-We'll continue to upload [static lists of submitted reports]({{ config.baseUrl }}status/findings) daily for audit resolution officials at least through April 16, 2024.
-
 <div class="usa-accordion usa-accordion--bordered">
 <h2 class="usa-accordion__heading">
   <button


### PR DESCRIPTION
This PR removes the link to the summary download page from [the FAC status page](https://federalist-35af9df5-a894-4ae9-aa3d-f6d95427c7bc.sites.pages.cloud.gov/preview/gsa-tts/fac-transition-site/lh/may-7-updates/status/) now that we're no longer updating those.