### PR TITLE
Lh/may fac updates

### DIFF
--- a/src/updates/archive.md
+++ b/src/updates/archive.md
@@ -282,7 +282,6 @@ We continue to work with Census on the migration of historic data.
 
 We completed the development work necessary to make it possible to unlock audits that had been locked for certification. Auditors and auditees are now able to unlock these audits to make further edits before re-locking for certification.
 
-
 ### What we delivered
 
 We work in [an agile manner](https://asana.com/resources/agile-methodology). That means we have a long-term strategy, medium-term features we work to deliver, and make continuous improvement and bug fixes to the existing product. We update our system through pull requests, or PRs.
@@ -334,6 +333,7 @@ The historical data migration occupies a lot of our team’s time. However, we a
 - Improving the visibility of findings on audits.
 
 - Providing summary reports for both single audit submissions and for all results of a search.
+
 </div>
 
 <h4 class="usa-accordion__heading">
@@ -501,6 +501,7 @@ Our priorities are:
 ### Opportunities
 
 Do you have an idea that could transform and improve grants management and oversight? 10x, a federal idea accelerator, is [accepting proposals for new investment opportunities](https://10x.gsa.gov/posts/2023-submission-period/). All Federal employees are invited to submit ideas by November 30th.
+  
   </div>
 
   <h4 class="usa-accordion__heading">
@@ -651,6 +652,7 @@ After releasing search, our priorities are:
 ### Opportunities
 
 Do you have an idea that could transform and improve grants management and oversight? 10x, a federal idea accelerator, is [accepting proposals for new investment opportunities](https://10x.gsa.gov/posts/2023-submission-period/). All Federal employees are invited to submit ideas by November 30th.
+  
   </div>
   
   <h4 class="usa-accordion__heading">
@@ -683,6 +685,7 @@ Our pending feature priorities are:
 - Adding the ability to add, remove, or change auditors and certifying officials who are attached to the audit.
 - Adding the ability to resubmit a previously submitted and completed audit.
 - Adding email notifications to alert auditees and auditors that a step is ready for them to complete.
+  
   </div>
 
   <h4 class="usa-accordion__heading">
@@ -719,6 +722,7 @@ Our other feature priorities are:
 - Adding the ability to add, remove, or change auditors and certifying officials who are attached to the audit.
 - Adding the ability to resubmit a previously submitted and completed audit.
 - Adding email notifications to alert auditees and auditors that a step is ready for them to complete.
+  
   </div>
 
   <h4 class="usa-accordion__heading">
@@ -748,6 +752,7 @@ We know that not every tool you are used to is currently available, and we are w
 Our goal is to be transparent and share our areas of focus. You can see what features are coming up in [our backlog](https://github.com/orgs/GSA-TTS/projects/13/views/1). 
 
 We are currently working on [search](https://github.com/GSA-TTS/FAC/issues/2236). This will give Federal and public users the ability to find and download completed audits. We track our [day-to-day work on our task board](https://github.com/orgs/GSA-TTS/projects/11).
+ 
   </div>
 
 

--- a/src/updates/archive.md
+++ b/src/updates/archive.md
@@ -11,17 +11,17 @@ meta:
 The FAC is committed to working transparently and openly. In addition to [our regular updates](https://www.fac.gov/info/updates/), you can find historical updates below.
 
 <div class="usa-accordion usa-accordion--bordered">
-<h4 class="usa-accordion__heading">
-  <button
-    type="button"
-    class="usa-accordion__button"
-    aria-expanded="true"
-    aria-controls="b-apr15"
-  >
+  <h4 class="usa-accordion__heading">
+    <button
+      type="button"
+      class="usa-accordion__button"
+      aria-expanded="true"
+      aria-controls="b-apr15"
+    >
     Week of April 15, 2024
-  </button>
-</h4>
-<div id="b-apr15" class="usa-accordion__content usa-prose">
+    </button>
+  </h4>
+  <div id="b-apr15" class="usa-accordion__content usa-prose">
 
 ## Week of April 15, 2024
 
@@ -749,4 +749,5 @@ Our goal is to be transparent and share our areas of focus. You can see what fea
 
 We are currently working on [search](https://github.com/GSA-TTS/FAC/issues/2236). This will give Federal and public users the ability to find and download completed audits. We track our [day-to-day work on our task board](https://github.com/orgs/GSA-TTS/projects/11).
   </div>
-</div>
+
+

--- a/src/updates/archive.md
+++ b/src/updates/archive.md
@@ -18,6 +18,56 @@ The FAC is committed to working transparently and openly. In addition to [our re
     aria-expanded="true"
     aria-controls="b-feb26"
   >
+    Week of April 15, 2024
+  </button>
+</h4>
+<div id="b-apr15" class="usa-accordion__content usa-prose">
+
+## Week of April 15, 2024
+
+### March peak season
+
+The FAC received 5,403 single audit submissions between March 25 and April 1. During this time, [our helpdesk](https://support.fac.gov/hc/en-us/requests/new) resolved more than 400 tickets, most via one-touch and in less than 24 hours.
+
+<div class="grid-container">
+    <div class="grid-row">
+        <div class="tablet:grid-col"><img src="{{ config.baseUrl }}assets/img/helpdesk/helpdesk_tickets_march.png" alt="bar chart of helpdesk tickets for the last week of March 2024" /></div>
+        <div class="tablet:grid-col"><img src="{{ config.baseUrl }}assets/img/helpdesk/helpdesk_response_march.png" alt="bar chart of response times to helpdesk tickets for the last week of March 2024" /></div>
+    </div>
+
+As the rate of submissions tapers off, the team is returning its focus to feature delivery and site maintenance.
+
+### Tribal API
+
+Tribal audits are now available to authorized users [via the API]({{ config.baseUrl }}api/tribal). Documentation on this process has been shared with interested agencies. If you would like to learn more about access to the API, please contact the FAC helpdesk.
+
+### Advanced search
+
+At the end of March, we experienced a performance outage for the FAC search. To resolve this, the team created [an advanced search option](https://app.fac.gov/dissemination/search/advanced/) to better serve audit resolution officials. A more [basic search option](https://app.fac.gov/dissemination/search/) is also still available for quicker confirmation of submitted reports.
+
+During the outage, we uploaded [daily findings workbooks]({{ config.baseUrl }}status/findings) to support resolution work. This page will remain available until May.
+
+### What's next?
+
+#### Resubmission
+
+The team is beginning the work on single audit resubmission. We're in the early stages of user interviews to determine the feature requirements. We're also talking with our agency partners about the resubmission process and how its triggered.
+
+#### May code freeze
+
+The FAC will undergo a code freeze from 5/17 - 5/31 to allow for security penetration testing. This testing is a required part of our authority to operate. During this time, we won't be making any updates to the FAC.
+
+<div class="usa-accordion usa-accordion--bordered">
+<h4 class="usa-accordion__heading">
+  <button
+    type="button"
+    class="usa-accordion__button"
+    aria-expanded="false"
+    aria-controls="b-feb26"
+  >
+
+  </div>
+  
     Week of February 26, 2024
   </button>
 </h4>

--- a/src/updates/archive.md
+++ b/src/updates/archive.md
@@ -59,7 +59,6 @@ The FAC will undergo a code freeze from 5/17 - 5/31 to allow for security penetr
 
 </div>
 
-<div class="usa-accordion usa-accordion--bordered">
 <h4 class="usa-accordion__heading">
   <button
     type="button"
@@ -134,8 +133,6 @@ We're keeping our focus on March. Looking ahead to the next few months, we'll be
 
 </div>
 
-
-<div class="usa-accordion usa-accordion--bordered">
 <h4 class="usa-accordion__heading">
   <button
     type="button"
@@ -155,7 +152,6 @@ The team has been focused on completing a migration of data from Census to GSA. 
 **Single Audit submissions from 2016–present are now available from the GSA FAC, and the Census Bureau is shutting down their data distribution.** Single Audits from prior years will appear in our search results. This is a major milestone, and future work will involve documenting the data migration, our continued curation of this data, and improvements to how this data is queried and used.
 
 The migration caused some disruptions to service. With 10 times more data, our system has struggled to keep up with volume for some of our search filters. The most affected filter is the ALN search. Results for this filter show whether an audit contains findings (“Findings My ALN/Findings Other ALN”). Before the migration, this filter applied to small amounts of data, but after adding prior years, this began crashing the system. We've removed this feature to resolve the system strain. Our team is working on a replacement feature to handle the larger amount of data.
-
 
 ### What we delivered
 
@@ -222,7 +218,6 @@ We're anticipating March to be a busy month. To support this, we'll be:
 
 </div>
 
-<div class="usa-accordion usa-accordion--bordered">
   <h4 class="usa-accordion__heading">
     <button
       type="button"
@@ -268,9 +263,9 @@ Auditors and auditees can now review a submission after it is validated and lock
 #### Historic data migration
 
 We continue to work with Census on the migration of historic data.
+
 </div>
 
-<div class="usa-accordion usa-accordion--bordered">
   <h4 class="usa-accordion__heading">
     <button
       type="button"
@@ -341,7 +336,6 @@ The historical data migration occupies a lot of our team’s time. However, we a
 - Providing summary reports for both single audit submissions and for all results of a search.
 </div>
 
-<div class="usa-accordion usa-accordion--bordered">
 <h4 class="usa-accordion__heading">
     <button
       type="button"
@@ -509,7 +503,6 @@ Our priorities are:
 Do you have an idea that could transform and improve grants management and oversight? 10x, a federal idea accelerator, is [accepting proposals for new investment opportunities](https://10x.gsa.gov/posts/2023-submission-period/). All Federal employees are invited to submit ideas by November 30th.
   </div>
 
-  <div class="usa-accordion usa-accordion--bordered">
   <h4 class="usa-accordion__heading">
     <button
       type="button"
@@ -660,7 +653,6 @@ After releasing search, our priorities are:
 Do you have an idea that could transform and improve grants management and oversight? 10x, a federal idea accelerator, is [accepting proposals for new investment opportunities](https://10x.gsa.gov/posts/2023-submission-period/). All Federal employees are invited to submit ideas by November 30th.
   </div>
   
-  <div class="usa-accordion usa-accordion--bordered">
   <h4 class="usa-accordion__heading">
     <button
       type="button"
@@ -693,7 +685,6 @@ Our pending feature priorities are:
 - Adding email notifications to alert auditees and auditors that a step is ready for them to complete.
   </div>
 
-  <div class="usa-accordion usa-accordion--bordered">
   <h4 class="usa-accordion__heading">
     <button
       type="button"
@@ -730,7 +721,6 @@ Our other feature priorities are:
 - Adding email notifications to alert auditees and auditors that a step is ready for them to complete.
   </div>
 
-  <div class="usa-accordion usa-accordion--bordered">
   <h4 class="usa-accordion__heading">
     <button
       type="button"

--- a/src/updates/archive.md
+++ b/src/updates/archive.md
@@ -16,7 +16,7 @@ The FAC is committed to working transparently and openly. In addition to [our re
     type="button"
     class="usa-accordion__button"
     aria-expanded="true"
-    aria-controls="b-feb26"
+    aria-controls="b-apr15"
   >
     Week of April 15, 2024
   </button>
@@ -341,6 +341,7 @@ The historical data migration occupies a lot of our team’s time. However, we a
 - Providing summary reports for both single audit submissions and for all results of a search.
 </div>
 
+<div class="usa-accordion usa-accordion--bordered">
 <h4 class="usa-accordion__heading">
     <button
       type="button"
@@ -508,6 +509,7 @@ Our priorities are:
 Do you have an idea that could transform and improve grants management and oversight? 10x, a federal idea accelerator, is [accepting proposals for new investment opportunities](https://10x.gsa.gov/posts/2023-submission-period/). All Federal employees are invited to submit ideas by November 30th.
   </div>
 
+  <div class="usa-accordion usa-accordion--bordered">
   <h4 class="usa-accordion__heading">
     <button
       type="button"
@@ -658,6 +660,7 @@ After releasing search, our priorities are:
 Do you have an idea that could transform and improve grants management and oversight? 10x, a federal idea accelerator, is [accepting proposals for new investment opportunities](https://10x.gsa.gov/posts/2023-submission-period/). All Federal employees are invited to submit ideas by November 30th.
   </div>
   
+  <div class="usa-accordion usa-accordion--bordered">
   <h4 class="usa-accordion__heading">
     <button
       type="button"
@@ -690,6 +693,7 @@ Our pending feature priorities are:
 - Adding email notifications to alert auditees and auditors that a step is ready for them to complete.
   </div>
 
+  <div class="usa-accordion usa-accordion--bordered">
   <h4 class="usa-accordion__heading">
     <button
       type="button"
@@ -726,6 +730,7 @@ Our other feature priorities are:
 - Adding email notifications to alert auditees and auditors that a step is ready for them to complete.
   </div>
 
+  <div class="usa-accordion usa-accordion--bordered">
   <h4 class="usa-accordion__heading">
     <button
       type="button"

--- a/src/updates/archive.md
+++ b/src/updates/archive.md
@@ -58,6 +58,7 @@ The team is beginning the work on single audit resubmission. We're in the early 
 The FAC will undergo a code freeze from 5/17 - 5/31 to allow for security penetration testing. This testing is a required part of our authority to operate. During this time, we won't be making any updates to the FAC.
 
 </div>
+</div>
 
 <h4 class="usa-accordion__heading">
   <button
@@ -753,5 +754,5 @@ Our goal is to be transparent and share our areas of focus. You can see what fea
 We are currently working on [search](https://github.com/GSA-TTS/FAC/issues/2236). This will give Federal and public users the ability to find and download completed audits. We track our [day-to-day work on our task board](https://github.com/orgs/GSA-TTS/projects/11).
  
   </div>
-</div>
+
 

--- a/src/updates/archive.md
+++ b/src/updates/archive.md
@@ -753,5 +753,5 @@ Our goal is to be transparent and share our areas of focus. You can see what fea
 We are currently working on [search](https://github.com/GSA-TTS/FAC/issues/2236). This will give Federal and public users the ability to find and download completed audits. We track our [day-to-day work on our task board](https://github.com/orgs/GSA-TTS/projects/11).
  
   </div>
-
+</div>
 

--- a/src/updates/archive.md
+++ b/src/updates/archive.md
@@ -66,7 +66,6 @@ The FAC will undergo a code freeze from 5/17 - 5/31 to allow for security penetr
     aria-expanded="false"
     aria-controls="b-feb26"
   >
-
     Week of February 26, 2024
   </button>
 </h4>

--- a/src/updates/archive.md
+++ b/src/updates/archive.md
@@ -57,6 +57,8 @@ The team is beginning the work on single audit resubmission. We're in the early 
 
 The FAC will undergo a code freeze from 5/17 - 5/31 to allow for security penetration testing. This testing is a required part of our authority to operate. During this time, we won't be making any updates to the FAC.
 
+</div>
+
 <div class="usa-accordion usa-accordion--bordered">
 <h4 class="usa-accordion__heading">
   <button
@@ -66,8 +68,6 @@ The FAC will undergo a code freeze from 5/17 - 5/31 to allow for security penetr
     aria-controls="b-feb26"
   >
 
-  </div>
-  
     Week of February 26, 2024
   </button>
 </h4>

--- a/src/updates/index.md
+++ b/src/updates/index.md
@@ -19,37 +19,17 @@ The Federal Audit Clearinghouse team works in the open. Our day-to-day task boar
 * Updates for [grantees and auditors](#grantees-and-auditors)
 * Updates for [agencies](#agencies)
 
-## Week of April 15, 2024
+## Week of May 6, 2024
 
-### March peak season
+### Resubmision
 
-The FAC received 5,403 single audit submissions between March 25 and April 1. During this time, [our helpdesk](https://support.fac.gov/hc/en-us/requests/new) resolved more than 400 tickets, most via one-touch and in less than 24 hours.
+We're continuing to work with our agency partners and OMB on single audit resubmission. We're conducting user interviews with inspectors general and audit resolution officials and consulting with OMB on policy.
 
-<div class="grid-container">
-    <div class="grid-row">
-        <div class="tablet:grid-col"><img src="{{ config.baseUrl }}assets/img/helpdesk/helpdesk_tickets_march.png" alt="bar chart of helpdesk tickets for the last week of March 2024" /></div>
-        <div class="tablet:grid-col"><img src="{{ config.baseUrl }}assets/img/helpdesk/helpdesk_response_march.png" alt="bar chart of response times to helpdesk tickets for the last week of March 2024" /></div>
-    </div>
+### Historical data migration
 
-As the rate of submissions tapers off, the team is returning its focus to feature delivery and site maintenance.
+The team continues to work on a remediation plan for the roughly 1,600 historical audits that failed the initial migration. These audits have a variety of data quality issues that we hope to resolve over the next few sprints
 
-### Tribal API
-
-Tribal audits are now available to authorized users [via the API]({{ config.baseUrl }}api/tribal). Documentation on this process has been shared with interested agencies. If you would like to learn more about access to the API, please contact the FAC helpdesk.
-
-### Advanced search
-
-At the end of March, we experienced a performance outage for the FAC search. To resolve this, the team created [an advanced search option](https://app.fac.gov/dissemination/search/advanced/) to better serve audit resolution officials. A more [basic search option](https://app.fac.gov/dissemination/search/) is also still available for quicker confirmation of submitted reports.
-
-During the outage, we uploaded [daily findings workbooks]({{ config.baseUrl }}status/findings) to support resolution work. This page will remain available until May.
-
-### What's next?
-
-#### Resubmission
-
-The team is beginning the work on single audit resubmission. We're in the early stages of user interviews to determine the feature requirements. We're also talking with our agency partners about the resubmission process and how its triggered.
-
-#### May code freeze
+### May code freeze
 
 The FAC will undergo a code freeze from 5/17 - 5/31 to allow for security penetration testing. This testing is a required part of our authority to operate. During this time, we won't be making any updates to the FAC.
 

--- a/src/updates/index.md
+++ b/src/updates/index.md
@@ -19,9 +19,9 @@ The Federal Audit Clearinghouse team works in the open. Our day-to-day task boar
 * Updates for [grantees and auditors](#grantees-and-auditors)
 * Updates for [agencies](#agencies)
 
-## Week of May 6, 2024
+## Week of May 13, 2024
 
-### Resubmision
+### Resubmission
 
 We're continuing to work with our agency partners and OMB on single audit resubmission. We're conducting user interviews with inspectors general and audit resolution officials and consulting with OMB on policy.
 

--- a/src/updates/index.md
+++ b/src/updates/index.md
@@ -9,7 +9,7 @@ include_survey: true
 
 # Updates from the FAC
 
-To help you understand our work through the transition, we’ll provide regular updates that talk about the work we’re doing and what’s next. 
+To help you understand our work, we’ll provide regular updates on the work we’re doing and what’s next. 
 
 The Federal Audit Clearinghouse team works in the open. Our day-to-day task board can be found on [Github](https://github.com/orgs/GSA-TTS/projects/11/views/2) and prior updates are available in [our archive]({{ config.baseUrl }}updates/archive).
 


### PR DESCRIPTION
This PR adds the May update to the [Updates from the FAC page](https://federalist-35af9df5-a894-4ae9-aa3d-f6d95427c7bc.sites.pages.cloud.gov/preview/gsa-tts/fac-transition-site/lh/may-fac-updates/updates/) based on the May AdComm presentation and moves the previous one to [the archive page](https://federalist-35af9df5-a894-4ae9-aa3d-f6d95427c7bc.sites.pages.cloud.gov/preview/gsa-tts/fac-transition-site/lh/may-fac-updates/updates/archive/).

![Screenshot 2024-05-09 at 08-44-12 Updates from the FAC](https://github.com/GSA-TTS/FAC-transition-site/assets/123114420/a5480b27-d41e-41d1-b10e-8eeb08e9b34e)
![Screenshot 2024-05-09 at 08-36-57 Archived updates from the FAC](https://github.com/GSA-TTS/FAC-transition-site/assets/123114420/2bf9fb93-6b9f-406e-a9bc-1be2b7f76e4d)
