### PR TITLE
Update NO FEAR Act link

### DIFF
--- a/src/_includes/footer.njk
+++ b/src/_includes/footer.njk
@@ -54,7 +54,7 @@
                     </li>
                     <li class="usa-identifier__required-links-item">
                         <a class="usa-identifier__required-link usa-link"
-                            href="https://www.gsa.gov/about-us/organization/office-of-civil-rights/notification-and-federal-employee-antidiscrimination-and-retaliation-act-of-2002"
+                            href="https://www.gsa.gov/reference/civil-rights-programs/the-no-fear-act"
                             title="View No FEAR Act data">
                             View No FEAR Act data
                         </a>


### PR DESCRIPTION
The existing NO FEAR Act link goes to a 404. This PR updates it to the current location. 