### PR TITLE
removing OMB link on updates page & adding 2024 compliance supplement

### DIFF
--- a/src/_collections/updates/2023-09-08-acee.md
+++ b/src/_collections/updates/2023-09-08-acee.md
@@ -2,4 +2,4 @@
 tags: submitters
 date: "2023-09-08"
 ---
-At this time, the FAC is not accepting submissions for Alternative Compliance Examination Engagements (ACEE). [The Office of Management and Budget (OMB) has granted an automatic extension for these entities for Audit Year 2023]({{ config.baseUrl }}omb).
+At this time, the FAC is not accepting submissions for Alternative Compliance Examination Engagements (ACEE).

--- a/src/compliance.md
+++ b/src/compliance.md
@@ -10,6 +10,7 @@ meta:
 
 These guides from the Office of Management and Budget (OMB) are meant to help auditors complete the single audit process. They include the Federal Agency Single Audit, Key Management Liaison, and Program Contacts in the appendices.
 
+- [2024 Compliance Supplement]({{ config.baseUrl }}assets/compliance/2024-Compliance-Supplement.pdf)
 - [2023 Compliance Supplement]({{ config.baseUrl }}assets/compliance/2023-Compliance-Supplement.pdf)
 - [2022 Compliance Supplement]({{ config.baseUrl }}assets/compliance/2022-Compliance-Supplement.pdf)
 - [2021 Compliance Supplement]({{ config.baseUrl }}assets/compliance/2021-Compliance-Supplement.pdf)


### PR DESCRIPTION
This PR completes the quarterly content review updates and includes the following changes:

- removes the extraneous information about ACEE extensions from [the Updates page](https://federalist-35af9df5-a894-4ae9-aa3d-f6d95427c7bc.sites.pages.cloud.gov/preview/gsa-tts/fac-transition-site/lh/june-27-updates/updates/)
- adds the 2024 Compliance Supplement to [the Compliance page](https://federalist-35af9df5-a894-4ae9-aa3d-f6d95427c7bc.sites.pages.cloud.gov/preview/gsa-tts/fac-transition-site/lh/june-27-updates/compliance/)

<img width="892" alt="Screenshot 2024-06-27 at 9 05 41 AM" src="https://github.com/GSA-TTS/FAC-transition-site/assets/123114420/8fa63031-5a54-47da-9c7c-7d09bbc51d64">
<img width="1036" alt="Screenshot 2024-06-27 at 9 07 32 AM" src="https://github.com/GSA-TTS/FAC-transition-site/assets/123114420/6dcab180-0237-4db8-b2c7-b4a9195edf46">
