### PR TITLE
Adding privacy policy link to footer

### DIFF
--- a/src/_includes/footer.njk
+++ b/src/_includes/footer.njk
@@ -59,6 +59,13 @@
                             View No FEAR Act data
                         </a>
                     </li>
+                    <li class="usa-identifier__required-links-item">
+                        <a class="usa-identifier__required-link usa-link"
+                           href="https://www.gsa.gov/website-information/website-policies#privacy"
+                           title="View privacy policy">
+                            View privacy policy
+                        </a>
+                    </li>
                 </ul>
             </div>
         </nav>


### PR DESCRIPTION
Addresses https://github.com/GSA-TTS/FAC/issues/3877

In this PR:
- Adding privacy policy link to footer

Testing:
- `npm run start`
- Head to http://localhost:8080/
- Footer should now have `View privacy policy`