### PR TITLE
Using noreferrer where target=blank

### DIFF
--- a/src/_includes/header.njk
+++ b/src/_includes/header.njk
@@ -1,6 +1,6 @@
 <div class="usa-overlay"></div>
 <header class="usa-header usa-header--extended">
-    
+
     <div class="usa-navbar">
             <div class="usa-logo" id="basic-logo">
                 <a class="usa-logo-link" href="{{ config.baseUrl }}">
@@ -57,7 +57,7 @@
                         {% endif %}
                     {% endfor %}
                     <li class="usa-nav__primary-item">
-                        <a class="usa-nav__link text-primary-dark" href="https://support.fac.gov/hc" target="_blank">
+                        <a class="usa-nav__link text-primary-dark" href="https://support.fac.gov/hc" target="_blank" rel="noopener noreferrer">
                             <span class="text-primary-dark">Helpdesk</span>
                         </a>
                     </li>

--- a/src/index.md
+++ b/src/index.md
@@ -45,7 +45,8 @@ include_survey: true
                             <div class="usa-card__container home-image searching shadow-1">
                                 <a class="usa-link text-white font-sans-2xl margin-0 text-semibold display-flex flex-column flex-align-center"
                                     href="https://app.fac.gov/dissemination/search/"
-                                    target="_blank">
+                                    target="_blank"
+                                    rel="noopener noreferrer">
                                     <p class="font-sans-2xl margin-0 display-block">Search</p>
                                     <p class="font-sans-xl margin-0">for audits</p>
                                 </a>


### PR DESCRIPTION
Addresses https://github.com/GSA-TTS/FAC/issues/3901

In this PR:
- Doing the same fix as was done for the main app [here](https://github.com/GSA-TTS/FAC/pull/4007)

Testing:
- Clicking the big "Search for Audits" button and the Helpdesk link should still open a new tab as normal