### PR TITLE
updating how-to guide for 24-hour wait

### DIFF
--- a/src/_collections/walkthrough/17-confirmation.md
+++ b/src/_collections/walkthrough/17-confirmation.md
@@ -7,6 +7,8 @@ The Auditee Certifying Official must complete this step.
 
 Once you submit your single audit package, you can't make any further changes. What you have submitted is what will be available via the FAC's audit search.
 
+After you submit your report to the FAC, it can take up to 24 hours for the system to process your upload. After this time, you will be able to download your report from the Search area of fac.gov.
+
 The date the Auditee Certifying Official confirms submission is recorded as the FAC acceptance date.
 
 We recommend you save a copy of your audit materials on your local machine. If you need to resubmit, having the originals will make the process much easier.

--- a/src/_collections/walkthrough/17-confirmation.md
+++ b/src/_collections/walkthrough/17-confirmation.md
@@ -7,7 +7,7 @@ The Auditee Certifying Official must complete this step.
 
 Once you submit your single audit package, you can't make any further changes. What you have submitted is what will be available via the FAC's audit search.
 
-After you submit your report to the FAC, it can take up to 24 hours for the system to process your upload. After this time, you will be able to download your report from the Search area of fac.gov.
+After you submit your report to the FAC, it can take up to 24 hours for the system to process your upload. After this time, you will be able to download your report when you [search the FAC database](https://app.fac.gov/dissemination/search/).
 
 The date the Auditee Certifying Official confirms submission is recorded as the FAC acceptance date.
 


### PR DESCRIPTION
This PR adds language to [the submission guide](https://federalist-35af9df5-a894-4ae9-aa3d-f6d95427c7bc.sites.pages.cloud.gov/preview/gsa-tts/fac-transition-site/lh/how-to-updates/audit-resources/how-to/#confirming-submission-2) re. the 24-hour wait to have full results available from search. This ties to [ticket #3890](https://github.com/GSA-TTS/FAC/issues/3890)

<img width="755" alt="Screenshot 2024-08-08 at 2 18 22 PM" src="https://github.com/user-attachments/assets/ed90ca1b-b16b-4e8a-b158-3bea168e6eda">
