### PR TITLE
Fix the Broken Link in /updates/archive/

### DIFF
--- a/src/updates/archive.md
+++ b/src/updates/archive.md
@@ -8,7 +8,7 @@ meta:
 
 # Archived updates from the FAC
 
-The FAC is committed to working transparently and openly. In addition to [our regular updates]({{ config.baseUrl }}/info/updates/), you can find historical updates below.
+The FAC is committed to working transparently and openly. In addition to [our regular updates]({{ config.baseUrl }}updates/), you can find historical updates below.
 
 <div class="usa-accordion usa-accordion--bordered">
   <h4 class="usa-accordion__heading">


### PR DESCRIPTION
# Fix the Broken Link in /updates/archive/

This link in the archived updates page doesn't work properly due to a duplicate forward slash:
![image](https://github.com/user-attachments/assets/c387d1bd-7245-4df1-b097-3fd3452fea1a)

## Changes:
Fix a broken link - /updates/archive/ to /updates/

## How to test:
1. Check out https://www.fac.gov/updates/archive/ - verify that the "our regular updates" link goes nowhere.
2. Switch to this branch and run normally, or host via federalist.
3. Verify that the link now properly navigates to /updates/