### PR TITLE
Include Qualtrics Survey

### DIFF
--- a/src/_includes/components/qualtrics.njk
+++ b/src/_includes/components/qualtrics.njk
@@ -1,0 +1,13 @@
+{# Snippet pulled directly from Qualtrics #}
+
+<!--BEGIN QUALTRICS WEBSITE FEEDBACK SNIPPET-->
+<script type='text/javascript'>
+(function(){var g=function(e,h,f,g){
+this.get=function(a){for(var a=a+"=",c=document.cookie.split(";"),b=0,e=c.length;b<e;b++){for(var d=c[b];" "==d.charAt(0);)d=d.substring(1,d.length);if(0==d.indexOf(a))return d.substring(a.length,d.length)}return null};
+this.set=function(a,c){var b="",b=new Date;b.setTime(b.getTime()+6048E5);b="; expires="+b.toGMTString();document.cookie=a+"="+c+b+"; path=/; "};
+this.check=function(){var a=this.get(f);if(a)a=a.split(":");else if(100!=e)"v"==h&&(e=Math.random()>=e/100?0:100),a=[h,e,0],this.set(f,a.join(":"));else return!0;var c=a[1];if(100==c)return!0;switch(a[0]){case "v":return!1;case "r":return c=a[2]%Math.floor(100/c),a[2]++,this.set(f,a.join(":")),!c}return!0};
+this.go=function(){if(this.check()){var a=document.createElement("script");a.type="text/javascript";a.src=g;document.body&&document.body.appendChild(a)}};
+this.start=function(){var t=this;"complete"!==document.readyState?window.addEventListener?window.addEventListener("load",function(){t.go()},!1):window.attachEvent&&window.attachEvent("onload",function(){t.go()}):t.go()};};
+try{(new g(100,"r","QSI_S_ZN_cN4gyJuBGhPsmcx","https://zncn4gyjubghpsmcx-cemgsa.gov1.siteintercept.qualtrics.com/SIE/?Q_ZID=ZN_cN4gyJuBGhPsmcx")).start()}catch(i){}})();
+</script><div id='ZN_cN4gyJuBGhPsmcx'><!--DO NOT REMOVE-CONTENTS PLACED HERE--></div>
+<!--END WEBSITE FEEDBACK SNIPPET-->

--- a/src/_includes/layout.njk
+++ b/src/_includes/layout.njk
@@ -9,14 +9,17 @@
               content="default-src 'self';
                     connect-src https://www.google-analytics.com https://gov1.siteintercept.qualtrics.com ws://localhost:8080/;
                     frame-src https://feedback.gsa.gov/;
-                    img-src 'self' https://touchpoints.app.cloud.gov https://gov1.siteintercept.qualtrics.com https://*.amazonaws.com/uploads/form/logo/3110/logo_square_Vector80w(2).jpg;
+                    img-src 'self' https://gov1.siteintercept.qualtrics.com https://*.amazonaws.com/uploads/form/logo/3110/logo_square_Vector80w(2).jpg;
                     object-src 'none';
-                    script-src 'self' 'unsafe-inline' https://gov1.siteintercept.qualtrics.com https://*.gov1.siteintercept.qualtrics.com https://dap.digitalgov.gov https://www.google-analytics.com https://www.googletagmanager.com http://search.usa.gov https://touchpoints.app.cloud.gov;
+                    script-src 'self' 'unsafe-inline' https://gov1.siteintercept.qualtrics.com https://*.gov1.siteintercept.qualtrics.com https://dap.digitalgov.gov https://www.google-analytics.com https://www.googletagmanager.com http://search.usa.gov;
                     style-src 'self' 'unsafe-inline';
                     worker-src 'none';">
         <meta name="{{meta.name}}" description="{{meta.description}}">
         <link rel="icon" type="image/x-icon" href="{{ config.baseUrl }}assets/img/favicons/icon_logo.svg" />
         <link rel="stylesheet" href="{{ config.baseUrl }}assets/css/styles.css" media="all" type="text/css">
+
+        {# Add Qualtrics feedback form to every page #}
+        {% include './components/qualtrics.njk' %}
         
         <title>{{ title }}</title>
     </head>
@@ -45,11 +48,4 @@
         //]]>
         </script>
     </body>
-    {% if include_survey %}
-        {# LEGACY - Add Touchpoints intercept #}
-        {# <script src="https://touchpoints.app.cloud.gov/touchpoints/9412c559.js" async></script> #}
-
-        {# Add Qualtrics feedback form #}
-        {% include './components/qualtrics.njk' %}
-    {% endif %}
 </html>

--- a/src/_includes/layout.njk
+++ b/src/_includes/layout.njk
@@ -9,7 +9,7 @@
               content="default-src 'self';
                     connect-src https://www.google-analytics.com https://gov1.siteintercept.qualtrics.com ws://localhost:8080/;
                     frame-src https://feedback.gsa.gov/;
-                    img-src 'self' https://touchpoints.app.cloud.gov https://*.amazonaws.com/uploads/form/logo/3110/logo_square_Vector80w(2).jpg;
+                    img-src 'self' https://touchpoints.app.cloud.gov https://gov1.siteintercept.qualtrics.com https://*.amazonaws.com/uploads/form/logo/3110/logo_square_Vector80w(2).jpg;
                     object-src 'none';
                     script-src 'self' 'unsafe-inline' https://gov1.siteintercept.qualtrics.com https://*.gov1.siteintercept.qualtrics.com https://dap.digitalgov.gov https://www.google-analytics.com https://www.googletagmanager.com http://search.usa.gov https://touchpoints.app.cloud.gov;
                     style-src 'self' 'unsafe-inline';

--- a/src/_includes/layout.njk
+++ b/src/_includes/layout.njk
@@ -5,11 +5,18 @@
         <meta charset="UTF-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://dap.digitalgov.gov https://www.google-analytics.com https://www.googletagmanager.com https://search.usa.gov https://touchpoints.app.cloud.gov; img-src 'self' https://touchpoints.app.cloud.gov; style-src 'self' 'unsafe-inline'; object-src 'none'; worker-src 'none'; connect-src https://www.google-analytics.com;">
+        <meta http-equiv="Content-Security-Policy" 
+              content="default-src 'self';
+                    script-src 'self' 'unsafe-inline' https://gov1.siteintercept.qualtrics.com https://*.gov1.siteintercept.qualtrics.com https://dap.digitalgov.gov https://www.google-analytics.com https://www.googletagmanager.com http://search.usa.gov https://touchpoints.app.cloud.gov;
+                    img-src 'self' https://touchpoints.app.cloud.gov https://*.amazonaws.com/uploads/form/logo/3110/logo_square_Vector80w(2).jpg;
+                    style-src 'self' 'unsafe-inline';
+                    object-src 'none';
+                    worker-src 'none';
+                    connect-src https://www.google-analytics.com https://gov1.siteintercept.qualtrics.com ws://localhost:8080/;">
         <meta name="{{meta.name}}" description="{{meta.description}}">
         <link rel="icon" type="image/x-icon" href="{{ config.baseUrl }}assets/img/favicons/icon_logo.svg" />
         <link rel="stylesheet" href="{{ config.baseUrl }}assets/css/styles.css" media="all" type="text/css">
-
+        
         {% include './components/qualtrics.njk' %}
         
         <title>{{ title }}</title>

--- a/src/_includes/layout.njk
+++ b/src/_includes/layout.njk
@@ -18,8 +18,6 @@
         <link rel="icon" type="image/x-icon" href="{{ config.baseUrl }}assets/img/favicons/icon_logo.svg" />
         <link rel="stylesheet" href="{{ config.baseUrl }}assets/css/styles.css" media="all" type="text/css">
         
-        {% include './components/qualtrics.njk' %}
-        
         <title>{{ title }}</title>
     </head>
 
@@ -34,11 +32,6 @@
 
         <!-- We participate in the US government's analytics program. See the data at analytics.usa.gov. -->
         <script async type="text/javascript" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA&subagency=TTS" id="_fed_an_ua_tag"></script>
-
-        <!-- Add Touchpoints intercept -->
-        <!--
-            <script src="https://touchpoints.app.cloud.gov/touchpoints/9412c559.js" async></script>
-        -->
         
         <script>
         //<![CDATA[
@@ -53,6 +46,10 @@
         </script>
     </body>
     {% if include_survey %}
-      <script src="https://touchpoints.app.cloud.gov/touchpoints/ba4ae239.js" async></script>
+        {# LEGACY - Add Touchpoints intercept #}
+        {# <script src="https://touchpoints.app.cloud.gov/touchpoints/9412c559.js" async></script> #}
+
+        {# Add Qualtrics feedback form #}
+        {% include './components/qualtrics.njk' %}
     {% endif %}
 </html>

--- a/src/_includes/layout.njk
+++ b/src/_includes/layout.njk
@@ -10,6 +10,8 @@
         <link rel="icon" type="image/x-icon" href="{{ config.baseUrl }}assets/img/favicons/icon_logo.svg" />
         <link rel="stylesheet" href="{{ config.baseUrl }}assets/css/styles.css" media="all" type="text/css">
 
+        {% include './components/qualtrics.njk' %}
+        
         <title>{{ title }}</title>
     </head>
 

--- a/src/_includes/layout.njk
+++ b/src/_includes/layout.njk
@@ -12,7 +12,8 @@
                     style-src 'self' 'unsafe-inline';
                     object-src 'none';
                     worker-src 'none';
-                    connect-src https://www.google-analytics.com https://gov1.siteintercept.qualtrics.com ws://localhost:8080/;">
+                    connect-src https://www.google-analytics.com https://gov1.siteintercept.qualtrics.com ws://localhost:8080/;
+                    frame-src https://feedback.gsa.gov/;">
         <meta name="{{meta.name}}" description="{{meta.description}}">
         <link rel="icon" type="image/x-icon" href="{{ config.baseUrl }}assets/img/favicons/icon_logo.svg" />
         <link rel="stylesheet" href="{{ config.baseUrl }}assets/css/styles.css" media="all" type="text/css">

--- a/src/_includes/layout.njk
+++ b/src/_includes/layout.njk
@@ -7,13 +7,13 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta http-equiv="Content-Security-Policy" 
               content="default-src 'self';
-                    script-src 'self' 'unsafe-inline' https://gov1.siteintercept.qualtrics.com https://*.gov1.siteintercept.qualtrics.com https://dap.digitalgov.gov https://www.google-analytics.com https://www.googletagmanager.com http://search.usa.gov https://touchpoints.app.cloud.gov;
-                    img-src 'self' https://touchpoints.app.cloud.gov https://*.amazonaws.com/uploads/form/logo/3110/logo_square_Vector80w(2).jpg;
-                    style-src 'self' 'unsafe-inline';
-                    object-src 'none';
-                    worker-src 'none';
                     connect-src https://www.google-analytics.com https://gov1.siteintercept.qualtrics.com ws://localhost:8080/;
-                    frame-src https://feedback.gsa.gov/;">
+                    frame-src https://feedback.gsa.gov/;
+                    img-src 'self' https://touchpoints.app.cloud.gov https://*.amazonaws.com/uploads/form/logo/3110/logo_square_Vector80w(2).jpg;
+                    object-src 'none';
+                    script-src 'self' 'unsafe-inline' https://gov1.siteintercept.qualtrics.com https://*.gov1.siteintercept.qualtrics.com https://dap.digitalgov.gov https://www.google-analytics.com https://www.googletagmanager.com http://search.usa.gov https://touchpoints.app.cloud.gov;
+                    style-src 'self' 'unsafe-inline';
+                    worker-src 'none';">
         <meta name="{{meta.name}}" description="{{meta.description}}">
         <link rel="icon" type="image/x-icon" href="{{ config.baseUrl }}assets/img/favicons/icon_logo.svg" />
         <link rel="stylesheet" href="{{ config.baseUrl }}assets/css/styles.css" media="all" type="text/css">

--- a/src/audit-resources/how-to.md
+++ b/src/audit-resources/how-to.md
@@ -50,5 +50,3 @@ inlcude_survey: true
         {% endfor %}
     </main>
 </div>
-
-<script src="https://touchpoints.app.cloud.gov/touchpoints/ba4ae239.js" async></script>

--- a/src/audit-resources/user-access.md
+++ b/src/audit-resources/user-access.md
@@ -52,5 +52,3 @@ The instructions below walk you through making changes to user roles. Once you h
   {% endif %}
 {% endfor %}
 </div>
-
-<script src="https://touchpoints.app.cloud.gov/touchpoints/ba4ae239.js" async></script>

--- a/src/index.md
+++ b/src/index.md
@@ -4,7 +4,6 @@ title: The Federal Audit Clearinghouse
 meta:
   name: The Federal Audit Clearinghouse
   description: The Federal Audit Clearinghouse is the home of the single audit process for the federal government awards system.
-include_survey: true
 ---
 <div class="home">
   <div class="grid-container">

--- a/src/tribal.md
+++ b/src/tribal.md
@@ -52,5 +52,3 @@ The instructions below walk you through searching for Tribal audits.
   {% endif %}
 {% endfor %}
 </div>
-
-<script src="https://touchpoints.app.cloud.gov/touchpoints/ba4ae239.js" async></script>

--- a/src/updates/index.md
+++ b/src/updates/index.md
@@ -4,7 +4,6 @@ title: Updates from the FAC
 meta:
   name: Updates from the Federal Audit Clearinghouse
   description: Stay up-to-date on the FAC transition and read the latest on the single audit process.
-include_survey: true
 ---
 
 # Updates from the FAC

--- a/src/welcome.md
+++ b/src/welcome.md
@@ -4,7 +4,6 @@ title: Welcome to the Federal Audit Clearinghouse
 meta:
   name: Welcome to the Federal Audit Clearinghouse
   description: The Federal Audit Clearinghouse is the home of the single audit process for the federal government awards system.
-include_survey: true
 ---
 
 # Welcome to the FAC


### PR DESCRIPTION
# Include Qualtrics Survey

Issue: https://github.com/GSA-TTS/FAC/issues/4129

**Cloud Gov Pages Link**: Preview the changes [here](https://federalist-35af9df5-a894-4ae9-aa3d-f6d95427c7bc.sites.pages.cloud.gov/preview/gsa-tts/fac-transition-site/jp/qualtrics-snippet/)!

## Changes:
1. Add Qualtrics to every page via a component included in the <head>
2. Rework the meta tag to allow Qualtrics, and reduce errors/warnings elsewhere
3. Remove Touchpoints
    i. Remove the snippet in `layout.njk`, as well as several other one-offs
    ii. Remove the tag `include_survey` in several files
    iii. Remove referenced to Touchpoints in the meta tag

## How to test:
1. Switch to this branch and run normally
2. Visit the locally hosted site
3. Verify via the browser console that the Qualtrics snippet fires

It will not work locally, but you will see requests to Qualtrics in the console. I believe there is some permissions wonk that prevents it from working locally. You can see the survey in action at the [preview url](https://federalist-35af9df5-a894-4ae9-aa3d-f6d95427c7bc.sites.pages.cloud.gov/preview/gsa-tts/fac-transition-site/jp/qualtrics-snippet/). 

## Screenshots:
![image](https://github.com/user-attachments/assets/2bcfda17-c4d8-4219-97fd-8bee9a8471be)

![image](https://github.com/user-attachments/assets/040fbeac-c1b3-43f2-9c06-4bf8a2ba2094)

