### PR TITLE
Remove outdated award reference number format

### DIFF
--- a/src/audit-resources/sf-sac/federal-awards-audit-findings.md
+++ b/src/audit-resources/sf-sac/federal-awards-audit-findings.md
@@ -27,7 +27,7 @@ Enter the award reference number as listed in SF-SAC Section 1: Federal Awards. 
 
 ### Column B: Audit Finding Reference Number
 
-Enter the audit finding reference number as listed in SF-SAC Section 1: Federal Awards. Audit finding reference numbers must be formatted “YYYY-###”.
+Enter the audit finding reference number as listed in SF-SAC Section 1: Federal Awards.
 
 ### Column C: Type(s) of Compliance Requirement(s)
 


### PR DESCRIPTION
Our award reference number format has changed from 4 digits to 5. Rather than update the text to the latest format, it might be easier just to leave the example text out. "Enter the audit finding reference number as listed in SF-SAC Section 1..." is probably sufficient. 