### PR TITLE
Fix Blank OMB Page

### DIFF
--- a/src/_collections/updates/2023-05-18.md
+++ b/src/_collections/updates/2023-05-18.md
@@ -1,5 +1,5 @@
 ---
-tags: post
+tags: ["omb", "post"]
 date: "2023-05-18"
 title: May 18th, 2023
 description: OMB updates and extensions


### PR DESCRIPTION
# Fix Blank OMB Page

## Problem
After merging https://github.com/GSA-TTS/FAC-transition-site/pull/164, the OMB page was left unintentionally blank. The update that should be there was wrapped into a single updates page, rather than displaying on the OMB page. 

## Change
1. Add 2023-05-18 post to both Updates and OMB page

## How to test
1. Switch to this branch and run everything normally. 
2. Verify that the [OMB page](http://localhost:8080/omb/) is no longer blank.
3. Verify that update [2023-05-18](http://localhost:8080/updates/2023-05-18/) still exists. 