### PR TITLE
Maintenance Banner for the Static Site

### DIFF
--- a/src/_includes/components/maintenance_banner.njk
+++ b/src/_includes/components/maintenance_banner.njk
@@ -1,0 +1,10 @@
+{# For display from 2024/12/05 to 2024/12/10. #}
+<section class="usa-alert usa-alert--warning margin-top-0" aria-label="Site alert">
+    <div class="usa-alert__body grid-container">
+        <h4 class="usa-alert__heading">Scheduled system maintenance</h4>
+        <p class="usa-alert__text">
+            FAC.gov will be performing maintenance on Tuesday, December 10, 2024 between 12:00 p.m. and 6:00 p.m ET.
+            During this period, the entire website will be unavailable.
+        </p>
+    </div>
+</section>

--- a/src/_includes/layout.njk
+++ b/src/_includes/layout.njk
@@ -25,6 +25,7 @@
     </head>
 
     <body>
+        {% include 'components/maintenance_banner.njk' %}
         {% include './components/usa-banner.njk' %}
         {% include 'header.njk' %}
         <main id="main-content">


### PR DESCRIPTION
# Maintenance Banner for the Static Site

Includes the maintenance banner on the static site. Here, we don't have access to the timing system the app has. Since this banner should already be displaying, I've just included it above the other banners.

We will have to undo these changes after the maintenance has been completed on Tuesday. Either by reverting this PR or simply striking the component. 