### PR TITLE
Fixing minor typo in api documentation

### DIFF
--- a/src/_collections/resources/api/06-results-management.md
+++ b/src/_collections/resources/api/06-results-management.md
@@ -1,6 +1,6 @@
 ---
 tags: resources, api
 header: Results management
-description: Tips for working within the API's request limit to to retrieve more than 20,000 results at a time.
+description: Tips for working within the API's request limit to retrieve more than 20,000 results at a time.
 link: 'api/results-management'
 ---


### PR DESCRIPTION
While reviewing our documentation I noticed a typo where the word "to" was written twice. Removing one of those tos. Tested locally using `npm run start`

Before:
![Screenshot 2024-12-12 at 7 31 05 AM](https://github.com/user-attachments/assets/9d047de3-11d6-4aa6-bb65-ca461b299689)

After:
![Screenshot 2024-12-12 at 9 01 02 AM](https://github.com/user-attachments/assets/e1430aa8-4b29-4765-be5d-d809153e6cb8)
