### PR TITLE
BUG: Reorder <head> to keep the <title>

### DIFF
--- a/src/_includes/layout.njk
+++ b/src/_includes/layout.njk
@@ -17,11 +17,10 @@
         <meta name="{{meta.name}}" description="{{meta.description}}">
         <link rel="icon" type="image/x-icon" href="{{ config.baseUrl }}assets/img/favicons/icon_logo.svg" />
         <link rel="stylesheet" href="{{ config.baseUrl }}assets/css/styles.css" media="all" type="text/css">
-
-        {# Add Qualtrics feedback form to every page #}
-        {% include './components/qualtrics.njk' %}
-        
         <title>{{ title }}</title>
+
+        {# Add Qualtrics feedback form to every page. Leave the snippet at the bottom of the head, as it adds to the top of the body and moves things around. #}
+        {% include './components/qualtrics.njk' %}
     </head>
 
     <body>


### PR DESCRIPTION
On fac.gov the title is in the body rather than the head. I believe the Qualtrics snippet is catching it and moving it down while it does its thing. So, let's move it down and leave the title be. 

## Change:
Move the Qualtrics snippet to the bottom of the head. 

## How to test:
1. Verify the title is in the body on fac.gov, and/or locally. 
2. Verify the title is back in the head on the temp site, and/or locally. 