### PR TITLE
New navigation component for submission guide

### DIFF
--- a/src/_collections/walkthrough/01-landing.md
+++ b/src/_collections/walkthrough/01-landing.md
@@ -1,5 +1,6 @@
 ---
 tags: walkthrough
+id: getting-started
 title: Getting started
 image: shared/home-annotated.png
 image_alt: A screenshot of the FAC home page. In the top right, the "sign in" button.

--- a/src/_collections/walkthrough/02-login.md
+++ b/src/_collections/walkthrough/02-login.md
@@ -1,5 +1,6 @@
 ---
 tags: walkthrough
+id: logging-in-with-login-gov
 title: Logging in with Login.gov
 image: shared/login.png
 image_alt: "A screenshot of the Login.gov login page. From top to bottom: an email address input, a password input, a 'Sign in' button, and a 'Create an Account' button."

--- a/src/_collections/walkthrough/03-create.md
+++ b/src/_collections/walkthrough/03-create.md
@@ -1,5 +1,6 @@
 ---
 tags: walkthrough
+id: your-single-audit-submissions
 title: Your single audit submissions
 image: walkthrough/walkthrough-03-create.png
 image_alt: "A screenshot of the FAC 'My submissions' page. From top to bottom: A table titled 'Audits in progress', a table titled 'Completed audits', a section titled 'Create a new audit', an unchecked box that reads, 'I agree to the terms and conditions'. At the bottom of the page, a disabled button reads, 'Start a new submission'."

--- a/src/_collections/walkthrough/04-eligibility.md
+++ b/src/_collections/walkthrough/04-eligibility.md
@@ -1,5 +1,6 @@
 ---
 tags: walkthrough
+id: submission-eligibility
 title: Submission eligibility
 image: walkthrough/walkthrough-04-eligibility.png
 image_alt: "A screenshot of the FAC submission eligibilty page. One multiple choice question and three true or false questions ask if an entity meets the single audit criteria."

--- a/src/_collections/walkthrough/05-auditee-info.md
+++ b/src/_collections/walkthrough/05-auditee-info.md
@@ -1,5 +1,6 @@
 ---
 tags: walkthrough
+id: auditee-information
 title: Auditee information
 image: walkthrough/walkthrough-05-auditee-info.png
 image_alt: "A screenshot of the FAC auditee information page. On the center left, there are three text input fields. From top to bottom: Entity UEI, Fiscal period start date, and Fiscal period end date."

--- a/src/_collections/walkthrough/06-audit-access.md
+++ b/src/_collections/walkthrough/06-audit-access.md
@@ -1,5 +1,6 @@
 ---
 tags: walkthrough
+id: audit-access
 title: Audit access
 image: walkthrough/walkthrough-06-audit-access.png
 image_alt: "A screenshot of the FAC audit submission access page. There are four sets of text input fields. Each set requests an email address, and a confirmation of the same address. From top to bottom, the sets are titled: Auditee certifying official, Auditor certifying official, Auditee contacts, Auditor contacts."

--- a/src/_collections/walkthrough/07-general-info.md
+++ b/src/_collections/walkthrough/07-general-info.md
@@ -1,5 +1,6 @@
 ---
 tags: walkthrough
+id: general-information-form
 title: General information form
 image: walkthrough/walkthrough-07-general-info.png
 image_alt: "A screenshot of the FAC general information page. The first three sections are visible. From top to bottom, they read: Fiscal Period, Type of audit, Audit period."

--- a/src/_collections/walkthrough/08-audit-info.md
+++ b/src/_collections/walkthrough/08-audit-info.md
@@ -1,5 +1,6 @@
 ---
 tags: walkthrough
+id: audit-information-form
 title: Audit information form
 image: walkthrough/walkthrough-08-audit-info.png
 image_alt: "A screenshot of the FAC audit information page. A series of questions determines details on the audit. The two sections are labeled 'Financial statements' and 'Federal programs'."

--- a/src/_collections/walkthrough/09-submission-checklist.md
+++ b/src/_collections/walkthrough/09-submission-checklist.md
@@ -1,5 +1,6 @@
 ---
 tags: walkthrough
+id: submission-checklist
 title: Submission checklist
 image: walkthrough/walkthrough-09-submission-checklist.png
 image_alt: "A screenshot of the FAC submission checklist page. A series of requirements are listed with links to their respective web forms. Sections that have already been completed are highlighted with green text, and have a green checkmark to their left. At the bottom, a section labeled 'Audit submission' is contained in a green box."

--- a/src/_collections/walkthrough/10-pdf.md
+++ b/src/_collections/walkthrough/10-pdf.md
@@ -1,5 +1,6 @@
 ---
 tags: walkthrough
+id: upload-the-audit-reporting-package-pdf
 title: Upload the audit reporting package PDF
 image: walkthrough/walkthrough-10-pdf.png
 image_alt: "A screenshot of the FAC single audit upload page. At the top of the image, formatting requirements are listed for a FAC-compliant PDF. Below the instructions, eleven text inputs ask for the page numbers of certain elements. Below the text inputs is a file input element."

--- a/src/_collections/walkthrough/11-workbook.md
+++ b/src/_collections/walkthrough/11-workbook.md
@@ -1,5 +1,6 @@
 ---
 tags: walkthrough
+id: upload-the-sf-sac
 title: Upload the SF-SAC
 image: walkthrough/walkthrough-11-workbook.png
 image_alt:  "A screenshot of a FAC workbook upload page. At the top of the image is the workbook title.  Below the title are links to the instructions and workbook download for this section. Below the links is a file input element. A disabled button below the file input reads, 'Return to Report Home'. To the right of this button a link reads, 'Cancel'."

--- a/src/_collections/walkthrough/12-tribal-data.md
+++ b/src/_collections/walkthrough/12-tribal-data.md
@@ -1,5 +1,6 @@
 ---
 tags: walkthrough
+id: tribal-data-release
 title: Tribal data release
 image: walkthrough/walkthrough-12-tribal-data.png
 image_alt:  A screenshot of the FAC "Tribal data release" page. At the top of the image is the page title.  Below the title is a brief to the citation for this section, which is followed by the certification section. In the certification section, are two fields for name and title of the auditee certifying official to agree and sign to the citation. A button below the section reads, 'Agree to Tribal data release'. To the right of this button a link reads, 'Cancel'.

--- a/src/_collections/walkthrough/13-validation.md
+++ b/src/_collections/walkthrough/13-validation.md
@@ -1,5 +1,6 @@
 ---
 tags: walkthrough
+id: pre-certification-validation
 title: Pre-certification validation
 image: walkthrough/walkthrough-13-validation.png
 image_alt:  A screenshot of the FAC validation page. At the top of the image is the page title.  Below the title is the instructions for this section, which is followed by a table that lists any errors. A button below the section reads, 'Begin validation'. To the right of this button, a disabled button reads 'Proceed to certification', then a link reads, 'Cancel'.

--- a/src/_collections/walkthrough/14-lock.md
+++ b/src/_collections/walkthrough/14-lock.md
@@ -1,5 +1,6 @@
 ---
 tags: walkthrough
+id: lock-for-certification
 title: Lock for certification
 image: walkthrough/walkthrough-14-lock.png
 image_alt:  A screenshot of the FAC lock for certification page. At the top of the image is the page title.  Below the title is the instructions. A button below the section reads, 'Lock for certification'. To the right of this button a link reads, 'Cancel'.

--- a/src/_collections/walkthrough/15-making-changes.md
+++ b/src/_collections/walkthrough/15-making-changes.md
@@ -1,5 +1,6 @@
 ---
 tags: walkthrough
+id: making-changes-to-your-audit-package
 title: Making changes to your audit package
 image: walkthrough/walkthrough-15-making-changes.png
 image_alt: A screenshot of the FAC submission checklist page. Two requirements are listed with links to their respective web forms. A button below the list reads, 'Lock for certification'. To the right of this button a link reads, 'Cancel'.

--- a/src/_collections/walkthrough/16-certification.md
+++ b/src/_collections/walkthrough/16-certification.md
@@ -1,5 +1,6 @@
 ---
 tags: walkthrough
+id: audit-certification-process
 title: Audit certification process
 image: walkthrough/walkthrough-16-certification.png
 image_alt: A screenshot of the FAC auditor certification checklist page. A list of checkboxes are listed with text requirements. A button below the list reads, 'Save and continue to next section'. To the right of this button a link reads, 'Cancel'.

--- a/src/_collections/walkthrough/17-confirmation.md
+++ b/src/_collections/walkthrough/17-confirmation.md
@@ -1,5 +1,6 @@
 ---
 tags: walkthrough
+id: confirming-submission
 title: Confirming submission
 image: walkthrough/walkthrough-17-confirmation.png
 image_alt: "A screenshot of a FAC confirmation page followed by instructions. The button below reads, 'Submit single audit package'. To the right of this button a link reads, 'Cancel'."

--- a/src/audit-resources/how-to.md
+++ b/src/audit-resources/how-to.md
@@ -16,43 +16,51 @@ eleventyComputed:
 ---
 {% import "components/image_modal.njk" as image_modal with context %}
 
-<div class="usa-in-page-nav-container">
-    <aside
-        class="usa-in-page-nav"
-        data-title-text="On this page"
-        data-title-heading-level="h2"
-        data-scroll-offset="25"
-        data-root-margin="0px 0px 0px 0px"
-        data-threshold="1"
-    ></aside>
-
-    <main id="main-content" class="main-content usa-prose">
-
+<div class="margin-y-4">
+    <div class="grid-row">
+        <nav class="desktop:grid-col-3 sticky-nav" aria-label="Secondary navigation">
+            <ul class="usa-sidenav">
+                <li class="usa-sidenav__item">
+                    <p><b>On this page</b></p>
+                    <ul class="usa-sidenav__sublist">
+                        {% for item in collections.walkthrough | sortAscendingByName %}
+                            {% if item.data.title | length %}
+<li class="usa-sidenav__item">
+    <a href="#{{item.data.id}}">{{item.data.title}}</a>
+</li>
+                            {% endif %}
+                        {% endfor %}
+                    </ul>
+                </li>
+            </ul>
+        </nav>
+        <main id="main-content" class="desktop:grid-col-8 main-content usa-prose">
 {# This has to be left aligned, or it won't convert to the h1 element. #}
 # Submitting single audit reports using the Federal Audit Clearinghouse
 
-        The Federal Audit Clearinghouse (FAC) is the place to submit federal grant audits. Entities that spend federal grant funds are required to submit an audit if they meet the following spending thresholds:
-* $750,000 or more for Fiscal Years starting before October 1, 2024  
-* $1,000,000 or more for Fiscal Years starting on or after October 1, 2024
+                    The Federal Audit Clearinghouse (FAC) is the place to submit federal grant audits. Entities that spend federal grant funds are required to submit an audit if they meet the following spending thresholds:
+            * $750,000 or more for Fiscal Years starting before October 1, 2024  
+            * $1,000,000 or more for Fiscal Years starting on or after October 1, 2024
 
-        
-        Our goal is to make the single audit submission process as easy as possible. To complete your audit, you'll fill out a series of webforms and upload a PDF of your audit reporting package. You'll also submit the SF-SAC as a series of XLSX workbooks.
+                    
+                    Our goal is to make the single audit submission process as easy as possible. To complete your audit, you'll fill out a series of webforms and upload a PDF of your audit reporting package. You'll also submit the SF-SAC as a series of XLSX workbooks.
 
-        Everyone who edits or certifies a single audit submission must have an account with [Login.gov](https://login.gov/). This includes auditees and auditors. [Creating a Login.gov account](https://login.gov/create-an-account/) is fully online and secure.
+                    Everyone who edits or certifies a single audit submission must have an account with [Login.gov](https://login.gov/). This includes auditees and auditors. [Creating a Login.gov account](https://login.gov/create-an-account/) is fully online and secure.
 
-        This guide goes through the submission process step-by-step.
+                    This guide goes through the submission process step-by-step.
 
-        {% for item in collections.walkthrough | sortAscendingByName %}
-            {% if item.data.title | length %}
-                    <div class="margin-top-8">
-                        <h2 id="{{ item.data.title | slugify }}">{{item.data.title}}</h2>
-                        <p>{{item.content | safe }}</p>
-                        {% if item.data.image %}
-                                <img class="cursor-pointer" src="{{config.baseUrl}}assets/img/{{item.data.image}}" width=500 style="margin: 1em; border: 1px solid #555;" aria-controls="image-modal-{{item.data.image}}" data-open-modal />
-                                {{ image_modal.modal(item.data.image, 'assets/img/' + item.data.image, item.data.image_alt) }}
+                    {% for item in collections.walkthrough | sortAscendingByName %}
+                        {% if item.data.title | length %}
+                                <div class="margin-top-8">
+                                    <h2 id="{{ item.data.title | slugify }}">{{item.data.title}}</h2>
+                                    <p>{{item.content | safe }}</p>
+                                    {% if item.data.image %}
+                                            <img class="cursor-pointer" src="{{config.baseUrl}}assets/img/{{item.data.image}}" width=500 style="margin: 1em; border: 1px solid #555;" aria-controls="image-modal-{{item.data.image}}" data-open-modal />
+                                            {{ image_modal.modal(item.data.image, 'assets/img/' + item.data.image, item.data.alt_text) }}
+                                    {% endif %}
+                                </div>
                         {% endif %}
-                    </div>
-            {% endif %}
-        {% endfor %}
-    </main>
+                    {% endfor %}
+        </main>
+    </div>
 </div>

--- a/src/scss/_guide.scss
+++ b/src/scss/_guide.scss
@@ -1,0 +1,15 @@
+@media (min-width: 64em) {
+    .grid-row {
+        gap: 2rem;
+    }
+    .sticky-nav {
+        align-self: flex-start;
+        position: sticky;
+        top: 0;
+    }
+}
+
+.grid-container .usa-sidenav {
+    margin-left: 0;
+    margin-right: 0;
+}

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -1,5 +1,6 @@
 @use '_header.scss';
 @use '_footer.scss';
+@use '_guide.scss';
 
 .usa-hero {
   background-image: none;


### PR DESCRIPTION
Addresses [#4616](https://github.com/GSA-TTS/FAC/issues/4616).

This PR introduces a new sticky navigation component for the submission guide page. This component persists on mobile screens as well, which is a feature the old component lacked. The component is also visually consistent with navigation from the FAC app.

<img width="350" alt="image" src="https://github.com/user-attachments/assets/d58f39fe-16f9-4e98-942b-c2ddb11c50f6" />

## Changelog
- Created "id" for each item in walkthrough collection. This is to reference the correct header for navigating the scrollbar.
- New `_guide.scss` for customized SCSS to handle the navigation component.

## How to test
1. Boot up the local application and navigate to the submission guide page.
2. Verify the component exists on all layout sizes.
3. Verify the contents of the component navigate to the correct sections of the submission guide.