### PR TITLE
Signup Page with API Data Gov Embed

### DIFF
--- a/src/_data/config.js
+++ b/src/_data/config.js
@@ -1,3 +1,5 @@
+const apiDataGovKey = "TEST_KEY";
 const baseUrl = process.env.BASEURL;
 
+exports.apiDataGovKey;
 exports.baseUrl = typeof baseUrl !== 'undefined' ? baseUrl + '/' : '/';

--- a/src/_includes/components/api_data_gov_signup.njk
+++ b/src/_includes/components/api_data_gov_signup.njk
@@ -1,0 +1,84 @@
+{# Snippet from api.data.gov to embed a sign up form.
+Edit the form configuration here, and the API key in `config.js`. #}
+
+<div id="apidatagov_signup">Loading signup form...</div>
+<script type="text/javascript">
+  /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
+  const apiDataGovKey = "{{ config.apiDataGovKey }}";
+  console.log(apiDataGovKey);
+  var apiUmbrellaSignupOptions = {
+    // Pick a short, unique name to identify your site, like 'gsa-auctions'
+    // in this example.
+    registrationSource: "gsa-fac",
+
+    // Enter the API key you signed up for and specially configured for this
+    // API key signup embed form.
+    apiKey: apiDataGovKey,
+
+    // Provide a URL or e-mail address to be used for customer support.
+    //
+    // The format for e-mail addresses can be given as either
+    // 'example@example.com' or 'mailto:example@example.com'.
+    contactUrl: "https://fac.gov/contact-resources/",
+
+    // OPTIONAL: Provide extra content to display on the signup confirmation
+    // page. This will be displayed below the user's API key and the example
+    // API URL are shown. HTML is allowed. Defaults to ""
+    // signupConfirmationMessage: '',
+
+    // OPTIONAL: Set to false to disable sending a welcome e-mail to the
+    // user after signing up. Defaults to true.
+    // sendWelcomeEmail: false,
+
+    // OPTIONAL: Show an intro paragraph explaining what the signup form is
+    // for.
+    // Defaults to false.
+    // showIntroText: true,
+
+    // OPTIONAL: Show a paragraph explaining that the asterisk denotes required
+    // fields in the form.
+    // Defaults to true.
+    // showRequiredAsteriskExplainText: false,
+
+    // OPTIONAL: Show the text input requesting the user's first name.
+    // Defaults to true.
+    // showFirstNameInput: false,
+
+    // OPTIONAL: Show the text input requesting the user's last name.
+    // Defaults to true.
+    // showLastNameInput: false,
+
+    // OPTIONAL: Show the textarea input asking how the user will use the APIs.
+    // Defaults to true.
+    // showUseDescriptionInput: false,
+
+    // OPTIONAL: Provide an extra input field to ask for the user's website.
+    // Defaults to false.
+    // showWebsiteInput: true,
+
+    // OPTIONAL: Provide an extra checkbox asking the user to agree to terms
+    // and conditions before signing up. Defaults to false.
+    // showTermsInput: true,
+
+    // OPTIONAL: If the terms & conditions checkbox is enabled, link to this
+    // URL for your API's terms & conditions. Defaults to "".
+    // termsUrl: "https://agency.gov/api-terms/",
+  };
+
+  /* * * DON'T EDIT BELOW THIS LINE * * */
+  (function () {
+    var apiUmbrella = document.createElement("script");
+    apiUmbrella.type = "text/javascript";
+    apiUmbrella.async = true;
+    apiUmbrella.src =
+      "https://api.data.gov/static/javascripts/signup_embed.js";
+    (
+      document.getElementsByTagName("head")[0] ||
+      document.getElementsByTagName("body")[0]
+    ).appendChild(apiUmbrella);
+  })();
+</script>
+<noscript>
+  Please enable JavaScript to signup for an
+  <a href="https://api.data.gov/">api.data.gov</a> API key.
+</noscript>

--- a/src/_includes/layout.njk
+++ b/src/_includes/layout.njk
@@ -7,12 +7,15 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta http-equiv="Content-Security-Policy" 
               content="default-src 'self';
-                    connect-src https://www.google-analytics.com https://gov1.siteintercept.qualtrics.com ws://localhost:8080/;
-                    frame-src https://feedback.gsa.gov/;
-                    img-src 'self' https://gov1.siteintercept.qualtrics.com https://*.amazonaws.com/uploads/form/logo/3110/logo_square_Vector80w(2).jpg;
+                    connect-src https://www.google-analytics.com https://gov1.siteintercept.qualtrics.com https://api.data.gov ws://localhost:8080/;
+                    frame-src https://feedback.gsa.gov/ https://www.google.com/recaptcha/ https://recaptcha.google.com/recaptcha/;
+                    img-src 'self' https://gov1.siteintercept.qualtrics.com https://*.amazonaws.com/uploads/form/logo/3110/logo_square_Vector80w(2).jpg data:;
                     object-src 'none';
-                    script-src 'self' 'unsafe-inline' https://gov1.siteintercept.qualtrics.com https://*.gov1.siteintercept.qualtrics.com https://dap.digitalgov.gov https://www.google-analytics.com https://www.googletagmanager.com http://search.usa.gov;
-                    style-src 'self' 'unsafe-inline';
+                    script-src 'self' 'unsafe-inline' https://gov1.siteintercept.qualtrics.com https://*.gov1.siteintercept.qualtrics.com 
+                        https://dap.digitalgov.gov https://www.google-analytics.com https://www.googletagmanager.com 
+                        http://search.usa.gov 
+                        https://api.data.gov https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/;
+                    style-src 'self' 'unsafe-inline' https://api.data.gov;
                     worker-src 'none';">
         <meta name="{{meta.name}}" description="{{meta.description}}">
         <link rel="icon" type="image/x-icon" href="{{ config.baseUrl }}assets/img/favicons/icon_logo.svg" />

--- a/src/api/signup.njk
+++ b/src/api/signup.njk
@@ -1,0 +1,31 @@
+---
+layout: home.njk
+title: FAC API resources
+header: API resources
+collectionName: resources, api
+meta:
+  name: FAC API signup
+  description: Sign up to access a FAC API key to download single audit data.
+eleventyComputed:
+  eleventyNavigation:
+    key: API signup
+    parent: API resources
+---
+<div class="grid-row padding-y-4">
+  <p>The FAC API shares public data from submitted audit reports.</p>
+
+  <p>To interact with the API, you will need an API key from Data.gov. To get a Data.gov API key, fill out the Data.gov API key signup form below. This is free and requires a valid email address. When you receive your API key, treat it like any other credential:</p>
+
+  <ul>
+    <li>Don't share your key with other users.</li>
+    <li>Don't commit your key into a repository alongside your code.</li>
+    <li>Don't store your key in a shared drive where other users have access.</li>
+    <li>Don't share your key in helpdesk requests or any other communication.</li>
+  </ul>
+
+  <p>Once you have your API key, you can begin exploring the API. Use the resources below to learn more about the API's capabilities.</p>
+
+  <p>For more information on the FAC API and the information it provides, see our <a href="{{ config.baseUrl }}api/terms/">terms and conditions</a>.</p>
+</div>
+
+{% include 'components/api_data_gov_signup.njk' %}


### PR DESCRIPTION
# Signup Page with API Data Gov Embed

First pass:
1. `/api/signup/` page
2. Pulls embed with default options from API Data Gov
    * No API key yet, so it shows an error. But, the form loads so we can see what it looks like

Screenshot:
![image](https://github.com/user-attachments/assets/312f98c9-50f6-4c8a-90ed-0e0f2348cd5f)
