### PR TITLE
Disable the Maintenance Banner

### DIFF
--- a/src/_includes/components/maintenance-banner.njk
+++ b/src/_includes/components/maintenance-banner.njk
@@ -1,3 +1,4 @@
+{# When including this component, be sure to change the date ranges and messagin appropriately. #}
 <section class="usa-alert usa-alert--warning margin-top-0" aria-label="Site alert">
     <div class="usa-alert__body grid-container">
       <h4 class="usa-alert__heading">Scheduled system maintenance</h4>

--- a/src/_includes/layout.njk
+++ b/src/_includes/layout.njk
@@ -28,7 +28,8 @@
 
     <body>
         {% include './components/usa-banner.njk' %}
-        {% include './components/maintenance-banner.njk' %}
+        {# To enable the maintenance banner, uncomment below. Be sure to change the messaging in the component. #}
+        {# {% include './components/maintenance-banner.njk' %} #}
         {% include 'header.njk' %}
         <main id="main-content">
             {{ content | safe }}


### PR DESCRIPTION
Does not delete it, in case we want it in the future.

Local screenshot, no banner:
![image](https://github.com/user-attachments/assets/d4483a6e-5d4f-4cff-b619-066a204cb181)
