### PR TITLE
Update federal-awards.md

### DIFF
--- a/src/audit-resources/sf-sac/federal-awards.md
+++ b/src/audit-resources/sf-sac/federal-awards.md
@@ -120,43 +120,43 @@ If the outstanding loan balance is not applicable, enter "N/A". For example, som
 
 If the award isn't a loan or loan guarantee (column L is “N”), leave this field blank. For more information on loan and loan guarantees, refer to [2 CFR 200.502(b)](https://www.ecfr.gov/current/title-2/part-200/section-200.502#p-200.502(b)).
 
-### Column N: Direct Award
+### Column N: Direct Award [Y/N]
 
-Select "Y" if the award came directly from a Federal awarding agency.  
+Select "Y" if a Federal awarding agency provided the award directly to you (the recipient).  
 
-If it didn't come directly from a Federal awarding agency, select "N" and complete column O.
+If a Federal awarding agency did not provide the Federal award directly to you (e.g., you received the award from a state government, local government, university, etc.), select "N" and complete column O.  Selecting “N” indicates this funding is an indirect award (not provided directly by a Federal awarding agency).
 
 This field can't be left blank.
 
-### Column O: If no (Direct Award), Name of Passthrough Entity
+### Column O: Name of Pass-through Entity for Indirect Award
 
-If column N is "N". this field can't be left blank. You must enter the name of your pass-through entity per [2 CFR 200.510(b)(2)](https://www.ecfr.gov/current/title-2/part-200/section-200.510#p-200.510(b)(2)).
+If column N is “N”, enter the name of the pass-through entity that provided you the (indirect) award, per 2 CFR 200.510(b)(2). If column N is "N" this field can't be left blank.
 
 If column N is "Y", you must leave this field blank.
 
-### Column P: If no (Direct Award), Identifying Number Assigned by the Pass-through Entity, if assigned
-
-If the award didn't come directly from a Federal awarding agency, enter the identifying number assigned by the pass-through entity.
+### Column P: Identifying Number Assigned by Pass-through Entity for Indirect Award, if assigned
+Enter the identifying number assigned by the pass-through entity that provided the indirect award, per 2 CFR 200.510(b)(2).
 
 If there isn't an identifying number assigned by the pass-through entity, leave this field blank.
 
 This field can't be blank if Direct Award (column N) is “N”.
 
-### Column Q: Federal Award Passed Through to Subrecipients
+If column N is "Y", you must leave this field blank.
 
-Select "Y" if the auditee entity passed on the Federal award to a subrecpient and complete column R.
+### Column Q: Funding provided to Subrecipients [Y/N]
 
-If the auditee entity didn’t pass on the Federal award to a subrecpient, select "N".
+Select "Y" if you provided all or a portion of the award to another entity (this is a subrecipient), and complete column R.
 
-Direct awards transferred within departments of the auditee entity are not considered passthrough funds.
+If you did not provide all or a portion of the award to another entity, select "N".
+
+Awards transferred between your departments (inside your entity) are not considered subawards and you should select “N”.
 
 This field can’t be left blank.
 
-### Column R: If yes (Passed Through), Amount Passed Through to Subrecipients
+### Column R: Amount Provided to Subrecipients
+If you provide all or a portion of the award to another entity, enter the amount provided to subrecipients, rounding to the nearest whole dollar, as required by  [2 CFR 200.510(b)(4)](https://www.ecfr.gov/current/title-2/part-200/section-200.510#p-200.510(b)(4)).
 
-Enter the amount passed through to the subrecipient, rounding to the nearest whole dollar, as required by [2 CFR 200.510(b)(4)](https://www.ecfr.gov/current/title-2/part-200/section-200.510#p-200.510(b)(4)).
-
-If Federal Award Passed Through (column Q) is “N”, leave this field blank.
+If column Q is “N”, leave this field blank.
 
 ### Column S: Major Program (MP)
 


### PR DESCRIPTION
#Summary

Updates Federal Awards documentation to clarify pass-through and subrecipient fields (Columns N–R) in the SF-SAC.

##Changes
Clarified direct vs. indirect awards (Column N)
Added requirements for pass-through entity fields (Columns O–P)
Clarified subrecipient definitions and exclusions (Column Q)
Defined when subrecipient amounts are required (Column R)

##Why
Aligns with 2 CFR 200.510
Reduces validation errors and user confusion
Implements SF-SAC Working Group recommendations

##Impact
Documentation-only update; improves user guidance and consistency.