### PR TITLE
Maintenance Banner and Resources Page Fixes

### DIFF
--- a/src/_collections/resources/audit_submission/01-submission-guide.md
+++ b/src/_collections/resources/audit_submission/01-submission-guide.md
@@ -1,5 +1,5 @@
 ---
-tags: resources, submission
+tags: resources-submission
 header: Submission guide
 description: An illustrated guide to the single audit process, from login to final submission.
 link: 'audit-resources/submission-guide/about/'

--- a/src/_collections/resources/audit_submission/02-SF-SAC.md
+++ b/src/_collections/resources/audit_submission/02-SF-SAC.md
@@ -1,5 +1,5 @@
 ---
-tags: resources, submission
+tags: resources-submission
 header: SF-SAC & instructions
 description: Download the SF-SAC workbooks and find instructions for completing them.
 link: 'audit-resources/sf-sac/'

--- a/src/_collections/resources/audit_submission/03-managing-access.md
+++ b/src/_collections/resources/audit_submission/03-managing-access.md
@@ -1,5 +1,5 @@
 ---
-tags: resources, submission
+tags: resources-submission
 header: Managing submission access
 description: Learn how to make changes to your certifying officials and audit submission editors.
 link: 'audit-resources/user-access/'

--- a/src/_collections/resources/audit_submission/04-burden-statement.md
+++ b/src/_collections/resources/audit_submission/04-burden-statement.md
@@ -1,5 +1,5 @@
 ---
-tags: resources, submission
+tags: resources-submission
 header: Burden statement
 description: The FAC follows the Paperwork Reduction Act. See the estimated burden of completing the single audit submission process.
 link: 'audit-resources/burden-statement/'

--- a/src/_collections/resources/audit_submission/05-glossary.md
+++ b/src/_collections/resources/audit_submission/05-glossary.md
@@ -1,0 +1,6 @@
+---
+tags: resources-submission
+header: Glossary
+description: Common terms, acronyms, and concepts used in the Federal Audit Clearinghouse (FAC) and the single audit process.
+link: 'audit-resources/glossary/'
+---

--- a/src/_collections/resources/contact/01-faq.md
+++ b/src/_collections/resources/contact/01-faq.md
@@ -1,5 +1,5 @@
 ---
-tags: resources, contact
+tags: resources-contact
 header: Fac.gov FAQ
 link: https://support.fac.gov/hc/en-us
 link_text: View FAQ

--- a/src/_collections/resources/contact/02-helpdesk.md
+++ b/src/_collections/resources/contact/02-helpdesk.md
@@ -1,5 +1,5 @@
 ---
-tags: resources, contact
+tags: resources-contact
 header: Helpdesk
 link: https://support.fac.gov/hc/en-us/requests/new
 link_text: Contact FAC Helpdesk

--- a/src/_collections/resources/contact/03-login.md
+++ b/src/_collections/resources/contact/03-login.md
@@ -1,5 +1,5 @@
 ---
-tags: resources, contact
+tags: resources-contact
 header: Login.gov
 link: https://www.login.gov/help/
 link_text: Contact Login.gov

--- a/src/_collections/resources/contact/04-cog-contacts.md
+++ b/src/_collections/resources/contact/04-cog-contacts.md
@@ -1,5 +1,5 @@
 ---
-tags: resources, contact
+tags: resources-contact
 header: Cognizant agency contacts
 link: 'contact-resources/cognizant-agency-contacts'
 link_text: View contacts

--- a/src/_collections/resources/contact/05-nsac-ksmal-pdf.md
+++ b/src/_collections/resources/contact/05-nsac-ksmal-pdf.md
@@ -1,5 +1,5 @@
 ---
-tags: resources, contact
+tags: resources-contact
 header: NSAC, KSAML and Federal program contacts
 link: assets/agency-contacts/2024-agency-contacts.pdf
 link_text: Download PDF

--- a/src/_collections/resources/search/01-basic-search-filters.md
+++ b/src/_collections/resources/search/01-basic-search-filters.md
@@ -1,5 +1,5 @@
 ---
-tags: resources, search
+tags: resources-search
 header: Basic search filters
 description: Learn about the FAC’s basic search filters and how to use them.
 link: 'search-resources/filters'

--- a/src/_collections/resources/search/02-advanced-search-filters.md
+++ b/src/_collections/resources/search/02-advanced-search-filters.md
@@ -1,5 +1,5 @@
 ---
-tags: resources, search
+tags: resources-search
 header: Advanced search filters
 description: Learn about the FAC’s advanced search filters and how to use them.
 link: 'search-resources/advanced'

--- a/src/_collections/resources/search/03-search-results.md
+++ b/src/_collections/resources/search/03-search-results.md
@@ -1,5 +1,5 @@
 ---
-tags: resources, search
+tags: resources-search
 header: Results tables definitions
 description: This guide explains the table headers and data definitions for FAC search results.
 link: 'search-resources/results-guide'

--- a/src/_includes/components/maintenance-banner.njk
+++ b/src/_includes/components/maintenance-banner.njk
@@ -1,10 +1,10 @@
-{# When including this component, be sure to change the date ranges and messagin appropriately. #}
+{# When including this component, be sure to change the date ranges and messaging appropriately. #}
 <section class="usa-alert usa-alert--warning margin-top-0" aria-label="Site alert">
     <div class="usa-alert__body grid-container">
       <h4 class="usa-alert__heading">Scheduled system maintenance</h4>
       <p class="usa-alert__text">
-        FAC.gov will be performing maintenance from Monday, April 21, 2025 between 9:00 AM and 6:00 PM ET.
-        During this period, the entire website may be unavailable.
+        FAC.gov will be performing maintenance from Monday, June 29, 2026 between 2:00 PM and 5:00 PM EDT.
+        During this period, API and analytics tools may be unavailable.
       </p>
   </div>
 </section>

--- a/src/_includes/layout.njk
+++ b/src/_includes/layout.njk
@@ -29,7 +29,7 @@
     <body>
         {% include './components/usa-banner.njk' %}
         {# To enable the maintenance banner, uncomment below. Be sure to change the messaging in the component. #}
-        {# {% include './components/maintenance-banner.njk' %} #}
+        {% include './components/maintenance-banner.njk' %}
         {# Similarly, enable the status banner below. Use in intances of app outages. The generic messaging is likely fine. #}
         {# {% include './components/status-banner.njk' %} #}
         {% include 'header.njk' %}

--- a/src/audit-resources/glossary.md
+++ b/src/audit-resources/glossary.md
@@ -1,6 +1,10 @@
 ---
 title: FAC Glossary
-layout: resources_page.njk
+layout: home.njk
+eleventyComputed:
+  eleventyNavigation:
+    key: Glossary
+    parent: Audit submission resources
 ---
 
 # Glossary

--- a/src/audit-resources/index.md
+++ b/src/audit-resources/index.md
@@ -2,7 +2,7 @@
 layout: resources_page.njk
 title: Audit submission resources
 header: Audit submission resources
-collectionName: resources, submission
+collectionName: resources-submission
 faqLink: https://support.fac.gov/hc/en-us/categories/18291221922829-Audit-Submission
 meta:
   name: Audit submission resources
@@ -14,5 +14,3 @@ eleventyComputed:
 ---
 
 We’re here to help make your audit submission as easy as possible. Use our submission resources to complete the process.
-
-- [Glossary](/audit-resources/glossary/)

--- a/src/contact-resources/index.md
+++ b/src/contact-resources/index.md
@@ -2,7 +2,7 @@
 layout: contact_page.njk
 title: Contact
 header: Have questions? Start here.
-collectionName: resources, contact
+collectionName: resources-contact
 meta:
   name: Contact
   description: Tools and resources for successfully submiting your single audit package to the Federal Audit Clearinghouse.

--- a/src/search-resources/index.md
+++ b/src/search-resources/index.md
@@ -2,7 +2,7 @@
 layout: resources_page.njk
 title: Audit search resources
 header: Audit search resources
-collectionName: resources, search
+collectionName: resources-search
 faqLink: https://support.fac.gov/hc/en-us/categories/18291273575181-Audit-Search
 meta:
   name: Audit search resources


### PR DESCRIPTION
1. A maintenance banner for next Monday. I gave a three hour window.
2. Fixes the resources pages.
    * I think something in an Eleventy 3.x release messed with collection behavior. The `resources, xyz` formatted was treated instead as `[resources, xyz]` and were not collected for each resources page.


Banner:
<img width="1471" height="435" alt="image" src="https://github.com/user-attachments/assets/bfc8f379-a206-47d4-bd51-92806cc1fb84" />
