### PR TITLE
Disabling Maintenance Banner

### DIFF
--- a/src/_includes/components/maintenance-banner.njk
+++ b/src/_includes/components/maintenance-banner.njk
@@ -3,8 +3,7 @@
     <div class="usa-alert__body grid-container">
       <h4 class="usa-alert__heading">Scheduled system maintenance</h4>
       <p class="usa-alert__text">
-        FAC.gov will be performing maintenance from Monday, June 29, 2026 between 2:00 PM and 5:00 PM EDT.
-        During this period, API and analytics tools may be unavailable.
+        The FAC application (app.fac.gov) is experiencing issues. We are investigating.
       </p>
   </div>
 </section>

--- a/src/_includes/layout.njk
+++ b/src/_includes/layout.njk
@@ -29,7 +29,7 @@
     <body>
         {% include './components/usa-banner.njk' %}
         {# To enable the maintenance banner, uncomment below. Be sure to change the messaging in the component. #}
-        {% include './components/maintenance-banner.njk' %}
+        {# {% include './components/maintenance-banner.njk' %} #}
         {# Similarly, enable the status banner below. Use in intances of app outages. The generic messaging is likely fine. #}
         {# {% include './components/status-banner.njk' %} #}
         {% include 'header.njk' %}


### PR DESCRIPTION
# Disabling Maintenance Banner

Following our most recent deploy.

Screenshot:
<img width="1378" height="428" alt="image" src="https://github.com/user-attachments/assets/e360c8c4-81fb-45ae-8d72-e7aa931edc0f" />
