### PR TITLE
Clarify audit finding reference source

### DIFF
--- a/src/audit-resources/sf-sac/federal-awards-audit-findings.md
+++ b/src/audit-resources/sf-sac/federal-awards-audit-findings.md
@@ -31,7 +31,7 @@ Enter the award reference number as listed in SF-SAC Section 1: Federal Awards. 
 
 ### Column B: Audit Finding Reference Number
 
-Enter the audit finding reference number as listed in SF-SAC Section 1: Federal Awards.
+Enter the audit finding reference number as listed in the audit report.
 
 ### Column C: Type(s) of Compliance Requirement(s)
 


### PR DESCRIPTION
Updated the description for the audit finding reference number to clarify that it should be listed in the audit report. https://github.com/GSA-TTS/FAC/issues/5526